### PR TITLE
Feature/#26 Topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 /src/main/resources/application-dev.yml
 /src/main/resources/application-prod.yml
 /src/main/resources/application-test.yml
+/src/main/resources/data.sql

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/Topic.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/Topic.java
@@ -1,0 +1,34 @@
+package com.HowBaChu.howbachu.domain.entity;
+
+import com.HowBaChu.howbachu.domain.entity.embedded.TopicSubTitle;
+import com.HowBaChu.howbachu.domain.entity.embedded.VotingStatus;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Topic {
+
+    @Id
+    @Column(name = "topic_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String title;
+
+    @Column(unique = true)
+    private LocalDate date;
+
+    @Embedded
+    private TopicSubTitle topicSubTitle;
+
+    @Embedded
+    private VotingStatus votingStatus;
+
+}

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/embedded/TopicSubTitle.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/embedded/TopicSubTitle.java
@@ -1,0 +1,16 @@
+package com.HowBaChu.howbachu.domain.entity.embedded;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicSubTitle {
+
+    private String subTitle_1;
+    private String subTitle_2;
+
+}

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/embedded/VotingStatus.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/embedded/VotingStatus.java
@@ -1,0 +1,11 @@
+package com.HowBaChu.howbachu.domain.entity.embedded;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class VotingStatus {
+
+    private int voteCount_A = 0;
+    private int voteCount_B = 0;
+
+}

--- a/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
+++ b/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
@@ -22,7 +22,10 @@ public enum ErrorCode {
     /* MEMBER */
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 회원입니다."),
     WRONG_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    FILE_NOT_EXIST(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다.");
+    FILE_NOT_EXIST(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
+
+    /* TOPIC */
+    TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "토픽 정보가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/HowBaChu/howbachu/repository/TopicRepository.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/TopicRepository.java
@@ -1,0 +1,8 @@
+package com.HowBaChu.howbachu.repository;
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+import com.HowBaChu.howbachu.repository.custom.TopicRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TopicRepository extends JpaRepository<Topic, Long>, TopicRepositoryCustom {
+}

--- a/src/main/java/com/HowBaChu/howbachu/repository/custom/TopicRepositoryCustom.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/custom/TopicRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.HowBaChu.howbachu.repository.custom;
+
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+
+import java.time.LocalDate;
+
+public interface TopicRepositoryCustom {
+    Topic getTopic(LocalDate date);
+}

--- a/src/main/java/com/HowBaChu/howbachu/repository/impl/TopicRepositoryCustomImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/impl/TopicRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package com.HowBaChu.howbachu.repository.impl;
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+import com.HowBaChu.howbachu.exception.CustomException;
+import com.HowBaChu.howbachu.exception.constants.ErrorCode;
+import com.HowBaChu.howbachu.repository.Support.Querydsl4RepositorySupport;
+import com.HowBaChu.howbachu.repository.custom.TopicRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static com.HowBaChu.howbachu.domain.entity.QTopic.topic;
+
+
+public class TopicRepositoryCustomImpl extends Querydsl4RepositorySupport implements TopicRepositoryCustom {
+
+    public TopicRepositoryCustomImpl() {
+        super(Topic.class);
+    }
+
+    @Override
+    public Topic getTopic(LocalDate date) {
+        return Optional.ofNullable(
+            selectFrom(topic)
+                .where(searchByDate(date))
+                .fetchOne()
+        ).orElseThrow(() -> new CustomException(ErrorCode.TOPIC_NOT_FOUND));
+    }
+
+    private BooleanExpression searchByDate(LocalDate date) {
+        return Optional.ofNullable(date).isPresent() ? topic.date.eq(date) : topic.date.eq(LocalDate.now());
+    }
+}

--- a/src/main/java/com/HowBaChu/howbachu/service/TopicService.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/TopicService.java
@@ -1,0 +1,14 @@
+package com.HowBaChu.howbachu.service;
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+
+import java.time.LocalDate;
+
+public interface TopicService {
+
+    /**
+     * 토픽 조회
+     */
+    public Topic getTopic(LocalDate date);
+
+}

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/TopicServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/TopicServiceImpl.java
@@ -1,0 +1,22 @@
+package com.HowBaChu.howbachu.service.impl;
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+import com.HowBaChu.howbachu.repository.TopicRepository;
+import com.HowBaChu.howbachu.service.TopicService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+
+@Service
+@RequiredArgsConstructor
+public class TopicServiceImpl implements TopicService {
+
+    private final TopicRepository topicRepository;
+
+    @Override
+    public Topic getTopic(LocalDate date) {
+        return topicRepository.getTopic(date);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   profiles:
     active: dev
+    include:
+      - s3
 
   jpa:
     open-in-view: false
@@ -20,3 +22,4 @@ logging:
   level:
     org.springframework.security: ERROR
     org.springframework.boot.autoconfigure.security: ERROR
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/src/test/java/com/HowBaChu/howbachu/repository/TopicRepositoryTest.java
+++ b/src/test/java/com/HowBaChu/howbachu/repository/TopicRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.HowBaChu.howbachu.repository;
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+import com.HowBaChu.howbachu.domain.entity.embedded.TopicSubTitle;
+import com.HowBaChu.howbachu.domain.entity.embedded.VotingStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles(value = "test")
+class TopicRepositoryTest {
+
+    @Autowired
+    TopicRepository topicRepository;
+
+    public void init() {
+        topicRepository.save(Topic.builder()
+            .title("탕수육은 부먹 or 찍먹")
+            .topicSubTitle(new TopicSubTitle("탕수육이 찍먹이다", "탕수육은 원래 부먹이다"))
+            .votingStatus(new VotingStatus())
+            .build());
+    }
+
+    @Test
+    public void TopicCreateTest() {
+
+        // given
+        Topic topic = Topic.builder()
+            .title("짜장® vs 짬뽕")
+            .topicSubTitle(new TopicSubTitle("짜장면이 진리다", "국물이 진리다. 짬뽕!"))
+            .votingStatus(new VotingStatus())
+            .build();
+
+        // when
+        Topic savedTopic = topicRepository.save(topic);
+
+        // then
+        Assertions.assertThat(savedTopic.getId()).isEqualTo(topic.getId());
+    }
+
+
+
+}

--- a/src/test/java/com/HowBaChu/howbachu/service/TopicServiceTest.java
+++ b/src/test/java/com/HowBaChu/howbachu/service/TopicServiceTest.java
@@ -1,0 +1,59 @@
+package com.HowBaChu.howbachu.service;
+
+import com.HowBaChu.howbachu.domain.entity.Topic;
+import com.HowBaChu.howbachu.domain.entity.embedded.TopicSubTitle;
+import com.HowBaChu.howbachu.domain.entity.embedded.VotingStatus;
+import com.HowBaChu.howbachu.repository.TopicRepository;
+import com.HowBaChu.howbachu.repository.custom.TopicRepositoryCustom;
+import com.HowBaChu.howbachu.service.impl.TopicServiceImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class TopicServiceTest {
+
+    @Mock
+    private TopicRepository topicRepository;
+
+    @Mock
+    private TopicRepositoryCustom topicRepositoryCustom;
+
+    @InjectMocks
+    private TopicServiceImpl topicService;
+
+    @Test
+    public void 토픽_조회() {
+
+        // given
+        Topic expectedTopic = Topic.builder()
+            .id(1L)
+            .title("부먹이냐 찍먹이냐")
+            .date(LocalDate.now())
+            .topicSubTitle(new TopicSubTitle("부먹이다", "찍먹이다"))
+            .votingStatus(new VotingStatus())
+            .build();
+
+        given(topicService.getTopic(null)).willReturn(expectedTopic);
+        given(topicService.getTopic(LocalDate.now())).willReturn(expectedTopic);
+
+        // when
+        Topic dateIsNullTopic = topicService.getTopic(null);
+        Topic dateIsTodayTopic = topicService.getTopic(LocalDate.now());
+
+        // then
+        Assertions.assertThat(dateIsNullTopic.getId()).isEqualTo(1L);
+        Assertions.assertThat(dateIsTodayTopic.getId()).isEqualTo(1L);
+
+        // null 값 유무에 따라서
+        System.out.println(dateIsNullTopic.equals(dateIsTodayTopic));
+    }
+}


### PR DESCRIPTION
기본적으로, Topic 엔티티 생성은 서버 측에서 임의로 데이터셋을 넣을 거기 때문에 기본적으로 조회용 쿼리문만 작성해서 구현함. 테스트 코드 통과했고 일단 명예의 전당은 구체적으로 어떤 식으로 조회할 지 모르겠어서 날짜를 기준으로 토픽을 조회할 수 있도록 작성함.