### PR TITLE
Fix: Cors 설정파일 추가

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/config/CorsConfig.java
+++ b/src/main/java/com/HowBaChu/howbachu/config/CorsConfig.java
@@ -1,0 +1,27 @@
+package com.HowBaChu.howbachu.config;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(
+            Arrays.asList("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS", "HEAD"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedHeaders(List.of("Authorization"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+}


### PR DESCRIPTION
- 리액트 주소에 맞춰 3000포트로 cors 설정 추가
- header에 "Authorization" 토큰 추가 가능
- 메서드 호출 가능
- Credential 사용 가능 (쿠키, Http 기본 인증 등)