### PR TITLE
[Refactor] refresh token rotate

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/config/JwtConfig.java
+++ b/src/main/java/com/HowBaChu/howbachu/config/JwtConfig.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
  * jwt secret key 관리 부분
  */
 @Configuration
-@PropertySource(value = {"classpath:secret.yml"}, factory = YamlLoadFactory.class)
+@PropertySource(value = {"classpath:secrets.yml"}, factory = YamlLoadFactory.class)
 @ConfigurationProperties(prefix = "jwt")
 @Getter
 @Setter

--- a/src/main/java/com/HowBaChu/howbachu/config/RedisInitializer.java
+++ b/src/main/java/com/HowBaChu/howbachu/config/RedisInitializer.java
@@ -1,0 +1,26 @@
+package com.HowBaChu.howbachu.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisInitializer implements CommandLineRunner {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void clearRedisData() {
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.flushAll();
+            return null;
+        });
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        clearRedisData();
+    }
+}

--- a/src/main/java/com/HowBaChu/howbachu/config/SwaggerConfig.java
+++ b/src/main/java/com/HowBaChu/howbachu/config/SwaggerConfig.java
@@ -24,7 +24,7 @@ public class SwaggerConfig {
     public Docket api() {
         return new Docket(DocumentationType.OAS_30)
             .securityContexts(Collections.singletonList(securityContext()))
-            .securitySchemes(List.of(apiKey()))
+            .securitySchemes(List.of(apiKey_AT(),apiKey_RT()))
             .select()
             .paths(PathSelectors.any())
             .build().apiInfo(apiInfo());
@@ -42,11 +42,14 @@ public class SwaggerConfig {
             "accessEverything");
         AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
         authorizationScopes[0] = authorizationScope;
-        return List.of(new SecurityReference("Authorization", authorizationScopes));
+        return List.of(new SecurityReference("Access-Token", authorizationScopes), new SecurityReference("Refresh-Token", authorizationScopes));
     }
 
-    private ApiKey apiKey() {
-        return new ApiKey("Authorization", "Authorization", "header");
+    private ApiKey apiKey_RT() {
+        return new ApiKey("Refresh-Token", "Refresh-Token", "header");
+    }
+    private ApiKey apiKey_AT() {
+        return new ApiKey("Access-Token", "Access-Token", "header");
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/java/com/HowBaChu/howbachu/config/SwaggerConfig.java
+++ b/src/main/java/com/HowBaChu/howbachu/config/SwaggerConfig.java
@@ -1,18 +1,11 @@
 package com.HowBaChu.howbachu.config;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.AuthorizationScope;
-import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -23,33 +16,9 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.OAS_30)
-            .securityContexts(Collections.singletonList(securityContext()))
-            .securitySchemes(List.of(apiKey_AT(),apiKey_RT()))
             .select()
             .paths(PathSelectors.any())
             .build().apiInfo(apiInfo());
-    }
-
-    // Spring Security
-    private SecurityContext securityContext() {
-        return SecurityContext.builder()
-            .securityReferences(defaultAuth())
-            .build();
-    }
-
-    private List<SecurityReference> defaultAuth() {
-        AuthorizationScope authorizationScope = new AuthorizationScope("global",
-            "accessEverything");
-        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
-        authorizationScopes[0] = authorizationScope;
-        return List.of(new SecurityReference("Access-Token", authorizationScopes), new SecurityReference("Refresh-Token", authorizationScopes));
-    }
-
-    private ApiKey apiKey_RT() {
-        return new ApiKey("Refresh-Token", "Refresh-Token", "header");
-    }
-    private ApiKey apiKey_AT() {
-        return new ApiKey("Access-Token", "Access-Token", "header");
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/java/com/HowBaChu/howbachu/controller/AuthController.java
+++ b/src/main/java/com/HowBaChu/howbachu/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto;
 import com.HowBaChu.howbachu.domain.dto.response.ResResult;
 import com.HowBaChu.howbachu.service.MemberService;
 import com.HowBaChu.howbachu.service.impl.MailServiceImpl;
+import java.net.http.HttpResponse;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,9 +38,9 @@ public class AuthController {
 
     /*로그인*/
     @PostMapping("/login")
-    public ResponseEntity<ResResult> login(@Valid @RequestBody MemberRequestDto.login requestDto) {
+    public ResponseEntity<ResResult> login(@Valid @RequestBody MemberRequestDto.login requestDto, HttpServletResponse response) {
         ResponseCode responseCode = ResponseCode.MEMBER_LOGIN;
-        return responseCode.toResponse(memberService.login(requestDto));
+        return responseCode.toResponse(memberService.login(requestDto, response));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/HowBaChu/howbachu/controller/AuthController.java
+++ b/src/main/java/com/HowBaChu/howbachu/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto;
 import com.HowBaChu.howbachu.domain.dto.response.ResResult;
 import com.HowBaChu.howbachu.service.MemberService;
 import com.HowBaChu.howbachu.service.impl.MailServiceImpl;
-import java.net.http.HttpResponse;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,8 +43,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<ResResult> logout(@ApiIgnore Authentication authentication) {
-        memberService.logout(authentication.getName());
+    public ResponseEntity<ResResult> logout(@ApiIgnore Authentication authentication, HttpServletResponse response) {
+        memberService.logout(authentication.getName(),response);
         ResponseCode responseCode = ResponseCode.MEMBER_LOGOUT;
         return responseCode.toResponse(null);
     }

--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/jwt/TokenResponseDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/jwt/TokenResponseDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class TokenResponseDto {
 
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/jwt/TokenResponseDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/jwt/TokenResponseDto.java
@@ -1,10 +1,12 @@
 package com.HowBaChu.howbachu.domain.dto.jwt;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class TokenResponseDto {
 
     private String accessToken;

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/RefreshToken.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/RefreshToken.java
@@ -22,5 +22,9 @@ public class RefreshToken {
 
     @Column
     private String value;
+
+    public void updateValue(String newRefreshToken) {
+        this.value = newRefreshToken;
+    }
 }
 

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/RefreshToken.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/RefreshToken.java
@@ -1,15 +1,15 @@
 package com.HowBaChu.howbachu.domain.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
-@Entity
+
+@RedisHash(value = "RefreshToken")
 @Getter
 @Builder
 @NoArgsConstructor
@@ -17,11 +17,10 @@ import lombok.NoArgsConstructor;
 public class RefreshToken {
 
     @Id
-    @Column(name = "refreshtoken_id")
     private String key;
-
-    @Column
     private String value;
+    @TimeToLive
+    private int expiration;
 
     public void updateValue(String newRefreshToken) {
         this.value = newRefreshToken;

--- a/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
+++ b/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 회원입니다."),
     WRONG_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     FILE_NOT_EXIST(HttpStatus.NOT_FOUND, "파일이 존재하지 않습니다."),
+    SEIZED_TOKEN_DETECTED(HttpStatus.FORBIDDEN, "토큰 정보가 잘못되었습니다."),
 
     /* VOTE */
     VOTE_ALREADY_DONE(HttpStatus.BAD_REQUEST, "이미 투표에 참가하셨습니다."),

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
@@ -1,18 +1,15 @@
 package com.HowBaChu.howbachu.jwt;
 
-import com.HowBaChu.howbachu.domain.entity.RefreshToken;
 import com.HowBaChu.howbachu.exception.CustomException;
 import com.HowBaChu.howbachu.exception.constants.ErrorCode;
 import com.HowBaChu.howbachu.repository.RefreshTokenRepository;
-
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,6 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
@@ -32,27 +30,79 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         // 토큰 꺼내기
-        String accessToken = resolveToken(request, "Authorization");
+        String accessToken = resolveToken(request, "Access-Token");
+        String refreshToken = resolveToken(request, "Refresh-Token");
 
-        if (accessToken == null) {
-            log.info("AccessToken이 비어있음.");
+        // 액세스 토큰과 리프레시 토큰이 모두 존재한다면
+        if (accessToken != null && refreshToken != null) {
+            // 리프레쉬 토큰이 유효하다면
+            if (refreshToken.equals(
+                refreshTokenRepository.findByKey(jwtProvider.getEmailFromToken(accessToken)).get()
+                    .getValue())) {
+                // 액세스 토큰이 유효하다면
+                if (jwtProvider.validateToken(accessToken)) {
+                    setAuthentication(jwtProvider.getEmailFromToken(accessToken), request);
+                    chain.doFilter(request, response);
+                }
+                // 액세스 토큰이 유효하지 않다면
+                else {
+                    // 리프레쉬 토큰이 유효하다면
+                    if (jwtProvider.validateToken(refreshToken)) {
+                        // 액세스 토큰 재발급
+                        String accessTokenNew = jwtProvider.createAccessToken(
+                            jwtProvider.getEmailFromToken(refreshToken));
+                        setAuthentication(jwtProvider.getEmailFromToken(accessTokenNew), request);
+                    }
+                    // 리프레쉬 토큰이 유효하지 않다면
+                    else {
+                        log.info("RefreshToken이 만료됨");
+                        throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+                    }
+                }
+            }
+        } else {
             chain.doFilter(request, response);
-            return;
+        }
+
+            // 액세스 토큰이 유효하지 않다면 -> 리프레쉬 토큰과 액세스 토큰 모두 갱신
+            // 리프레쉬 토큰이 유효하지 않다면 -> 탈취 확인
+        // 둘 중 하나라도 없다면 로그인 필요
+
+
+        /*if (accessToken == null) {
+            log.info("AccessToken이 비어있음.");
+            throw new CustomException(ErrorCode.NO_JWT_TOKEN);
+        }
+
+        if (refreshToken == null) {
+            log.info("RefreshToken이 비어있음.");
+            throw new CustomException(ErrorCode.NO_JWT_TOKEN);
         }
 
         Boolean accessTokenStatus = jwtProvider.validateToken(accessToken);
         String email = jwtProvider.getEmailFromToken(accessToken);
-        Optional<RefreshToken> refreshToken = refreshTokenRepository.findByKey(email);
+        Optional<RefreshToken> refreshTokenOld = refreshTokenRepository.findByKey(email);
 
         if (accessTokenStatus) {
             setAuthentication(email, request);
         } // 액세스 토큰이 유효하다면
-        else if (refreshToken.isPresent()) {
+        else if (refreshTokenOld.isPresent()) {
+            if (!refreshToken.equals(refreshTokenOld)) {
+                log.info("탈취된 토큰으로 접근 시도");
+                throw new CustomException(ErrorCode.HACKED_TOKEN);
+            }
             log.info("AccessToken이 만료됨");// 액세스 토큰이 만료되었으며 리프레쉬토큰이 존재하는 경우
-            if (jwtProvider.validateToken(refreshToken.get().getValue())) { // 액세스 토큰이 만려되면 리프레쉬 토큰으로 새로운 액세스 토큰 발급
-                String newAccessToken = jwtProvider.createAccessToken(email);
-                jwtProvider.setHeaderAccessToken(response, newAccessToken);
-                setAuthentication(jwtProvider.getEmailFromToken(newAccessToken), request);
+            if (jwtProvider.validateToken(refreshTokenOld.get().getValue())) { // 액세스 토큰이 만려되면 리프레쉬 토큰으로 새로운 액세스 토큰 발급
+                log.info("RefreshToken이 유효함");
+
+                String accessTokenNew = jwtProvider.createAccessToken(email);
+                jwtProvider.setHeaderAccessToken(response, accessTokenNew);
+
+                String refreshTokenNew = jwtProvider.createRefreshToken();
+                refreshTokenOld.get().updateValue(refreshTokenNew);
+                jwtProvider.setHeaderRefreshToken(response, refreshTokenNew);
+
+                setAuthentication(email, request);
             } else {
                 log.info("RefreshToken이 만료됨");
                 throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
@@ -61,7 +111,7 @@ public class JwtFilter extends OncePerRequestFilter {
             log.info("RefreshToken이 존재하지 않음. 재로그인 필요.");
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         } // 액세스 토큰이 만료되고 리프레쉬 토큰이 존재하지 않는 경우
-        chain.doFilter(request, response);
+        chain.doFilter(request, response);*/
     }
 
 
@@ -79,8 +129,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
     // 요청에 담긴 헤더에서 토큰값 가져오기
     // 토큰의 타입에 따라 다르게 가져올 수 있음.
-    private String resolveToken(HttpServletRequest request, String tokenType) {
-        String headerAuth = request.getHeader("Authorization");
+    private static String resolveToken(HttpServletRequest request, String tokenType) {
+        String headerAuth = request.getHeader(tokenType);
         if (StringUtils.hasText(headerAuth)) {
             return headerAuth;
         }

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
@@ -34,11 +34,11 @@ public class JwtFilter extends OncePerRequestFilter {
         // 토큰 꺼내기
         String accessToken = resolveTokenFromCookie(request, "Access-Token");
         String refreshToken = resolveTokenFromCookie(request, "Refresh-Token");
-        log.info(accessToken, refreshToken);
+        log.info(accessToken+" // " +refreshToken);
         // 액세스 토큰과 리프레시 토큰이 모두 존재한다면
         if (accessToken != null && refreshToken != null) {
             String email = jwtProvider.getEmailFromToken(accessToken);
-            RefreshToken refreshTokenOld = refreshTokenRepository.findByKey(email)
+            RefreshToken refreshTokenOld = refreshTokenRepository.findById(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
             // RTR을 통과한다면
             if (refreshToken.equals(refreshTokenOld.getValue())) {

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
@@ -53,8 +53,8 @@ public class JwtFilter extends OncePerRequestFilter {
                     if (jwtProvider.validateToken(refreshToken)) {
                         // 액세스 토큰 재발급
                         TokenDto tokenDto = jwtProvider.generateJwtToken(jwtProvider.getEmailFromToken(refreshToken));
-                        jwtProvider.setCookieAccessToken(response, tokenDto.getAccessToken());
-                        jwtProvider.setCookieRefreshToken(response, tokenDto.getRefreshToken());
+                        jwtProvider.setCookieAccessToken(response, tokenDto.getAccessToken(), jwtProvider.getAccessTokenExpiredTime());
+                        jwtProvider.setCookieRefreshToken(response, tokenDto.getRefreshToken(), jwtProvider.getRefreshTokenExpiredTime());
                         refreshTokenOld.updateValue(tokenDto.getRefreshToken());
                         setAuthentication(email, request);
                     }

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
@@ -71,6 +71,10 @@ public class JwtProvider {
         response.setHeader("Authorization", accessToken);
     }
 
+    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
+        response.setHeader("RefreshToken", refreshToken);
+    }
+
 
     /**
      * @param token Claims 부분을 가져올 token

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
@@ -113,4 +113,11 @@ public class JwtProvider {
         return true;
     }
 
+    public int getAccessTokenExpiredTime() {
+        return jwtConfig.getAccessExpirationTime();
+    }
+
+    public int getRefreshTokenExpiredTime() {
+        return jwtConfig.getRefreshExpirationTime();
+    }
 }

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
@@ -11,11 +11,10 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
-
 import java.util.Base64;
 import java.util.Date;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -51,7 +50,6 @@ public class JwtProvider {
             .compact();
     }
 
-
     /**
      * @return 새로운 refreshToken 발급
      */
@@ -62,19 +60,21 @@ public class JwtProvider {
             .compact();
     }
 
-
-    /**
-     * @param response    클라이언트에 전달할 response
-     * @param accessToken 헤더에 저장할 액세스 토큰
-     */
-    public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
-        response.setHeader("Authorization", accessToken);
+    public void setCookieAccessToken(HttpServletResponse response, String accessToken) {
+        Cookie cookie = new Cookie("Access-Token", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(jwtConfig.getAccessExpirationTime());  // 30분
+        response.addCookie(cookie);
     }
 
-    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
-        response.setHeader("RefreshToken", refreshToken);
+    public void setCookieRefreshToken(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("Refresh-Token", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(jwtConfig.getRefreshExpirationTime());  // 2주
+        response.addCookie(cookie);
     }
-
 
     /**
      * @param token Claims 부분을 가져올 token

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtProvider.java
@@ -60,19 +60,19 @@ public class JwtProvider {
             .compact();
     }
 
-    public void setCookieAccessToken(HttpServletResponse response, String accessToken) {
+    public void setCookieAccessToken(HttpServletResponse response, String accessToken, int expiredTime) {
         Cookie cookie = new Cookie("Access-Token", accessToken);
         cookie.setHttpOnly(true);
         cookie.setPath("/");
-        cookie.setMaxAge(jwtConfig.getAccessExpirationTime());  // 30분
+        cookie.setMaxAge(expiredTime);  // 30분
         response.addCookie(cookie);
     }
 
-    public void setCookieRefreshToken(HttpServletResponse response, String refreshToken) {
+    public void setCookieRefreshToken(HttpServletResponse response, String refreshToken, int expiredTime) {
         Cookie cookie = new Cookie("Refresh-Token", refreshToken);
         cookie.setHttpOnly(true);
         cookie.setPath("/");
-        cookie.setMaxAge(jwtConfig.getRefreshExpirationTime());  // 2주
+        cookie.setMaxAge(expiredTime);  // 2주
         response.addCookie(cookie);
     }
 

--- a/src/main/java/com/HowBaChu/howbachu/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/RefreshTokenRepository.java
@@ -1,14 +1,7 @@
 package com.HowBaChu.howbachu.repository;
 
 import com.HowBaChu.howbachu.domain.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
 
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
-
-    Optional<RefreshToken> findByKey(String email);
-
-    void deleteByKey(String email);
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/com/HowBaChu/howbachu/service/MemberService.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/MemberService.java
@@ -32,7 +32,7 @@ public interface MemberService {
     /*닉네임 중복검사*/
     StatusResponseDto checkUsernameDuplicate(String username);
 
-    void logout(String email);
+    void logout(String email, HttpServletResponse response);
 
     MemberResponseDto uploadAvatar(String email, MultipartFile image);
 

--- a/src/main/java/com/HowBaChu/howbachu/service/MemberService.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/MemberService.java
@@ -4,6 +4,7 @@ import com.HowBaChu.howbachu.domain.dto.jwt.TokenResponseDto;
 import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto;
 import com.HowBaChu.howbachu.domain.dto.member.MemberResponseDto;
 import com.HowBaChu.howbachu.domain.dto.member.StatusResponseDto;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,7 +15,7 @@ public interface MemberService {
     MemberResponseDto signup(MemberRequestDto.signup requestDto);
 
     /*로그인*/
-    TokenResponseDto login(MemberRequestDto.login requestDto);
+    TokenResponseDto login(MemberRequestDto.login requestDto, HttpServletResponse response);
 
     /*회원 상세정보*/
     MemberResponseDto findMemberDetail(String email);

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
@@ -55,7 +55,7 @@ public class MemberServiceImpl implements MemberService {
         }
         refreshTokenRepository.save(new RefreshToken(member.getEmail(), tokenDto.getRefreshToken()));
 
-        return new TokenResponseDto(tokenDto.getAccessToken());
+        return new TokenResponseDto(tokenDto.getAccessToken(),tokenDto.getRefreshToken());
     }
 
     @Override

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
@@ -55,7 +55,10 @@ public class MemberServiceImpl implements MemberService {
         }
         refreshTokenRepository.save(new RefreshToken(member.getEmail(), tokenDto.getRefreshToken()));
 
-        return new TokenResponseDto(tokenDto.getAccessToken(),tokenDto.getRefreshToken());
+        return TokenResponseDto.builder()
+            .accessToken(tokenDto.getAccessToken())
+            .refreshToken(tokenDto.getRefreshToken())
+            .build();
     }
 
     @Override

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.HowBaChu.howbachu.service.impl;
 
+import com.HowBaChu.howbachu.config.JwtConfig;
 import com.HowBaChu.howbachu.core.manager.AWSFileManager;
 import com.HowBaChu.howbachu.domain.dto.jwt.TokenDto;
 import com.HowBaChu.howbachu.domain.dto.jwt.TokenResponseDto;
@@ -33,6 +34,7 @@ public class MemberServiceImpl implements MemberService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
     private final AWSFileManager awsFileManager;
+    private final JwtConfig jwtConfig;
 
     @Override
     public MemberResponseDto signup(MemberRequestDto.signup requestDto) {
@@ -57,8 +59,10 @@ public class MemberServiceImpl implements MemberService {
 
         refreshTokenRepository.save(new RefreshToken(member.getEmail(), tokenDto.getRefreshToken(), jwtProvider.getRefreshTokenExpiredTime()));
         // cookie 설정
-        jwtProvider.setCookieAccessToken(response, tokenDto.getAccessToken());
-        jwtProvider.setCookieRefreshToken(response, tokenDto.getRefreshToken());
+        jwtProvider.setCookieAccessToken(response, tokenDto.getAccessToken(),
+            jwtProvider.getAccessTokenExpiredTime());
+        jwtProvider.setCookieRefreshToken(response, tokenDto.getRefreshToken(),
+            jwtProvider.getRefreshTokenExpiredTime());
 
         return TokenResponseDto.builder()
             .accessToken(tokenDto.getAccessToken())
@@ -98,7 +102,9 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void logout(String email) {
+    public void logout(String email, HttpServletResponse response){
+        jwtProvider.setCookieAccessToken(response, "", 0);
+        jwtProvider.setCookieRefreshToken(response, "", 0);
         refreshTokenRepository.deleteById(email);
     }
 

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
@@ -14,6 +14,7 @@ import com.HowBaChu.howbachu.jwt.JwtProvider;
 import com.HowBaChu.howbachu.repository.MemberRepository;
 import com.HowBaChu.howbachu.repository.RefreshTokenRepository;
 import com.HowBaChu.howbachu.service.MemberService;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -40,7 +41,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public TokenResponseDto login(MemberRequestDto.login requestDto) {
+    public TokenResponseDto login(MemberRequestDto.login requestDto, HttpServletResponse response) {
 
         Member member = memberRepository.findByEmail(requestDto.getEmail());
 
@@ -53,7 +54,11 @@ public class MemberServiceImpl implements MemberService {
         if (refreshTokenRepository.findById(member.getEmail()).isPresent()) {
             refreshTokenRepository.deleteById(member.getEmail());
         }
+
         refreshTokenRepository.save(new RefreshToken(member.getEmail(), tokenDto.getRefreshToken(), jwtProvider.getRefreshTokenExpiredTime()));
+        // cookie 설정
+        jwtProvider.setCookieAccessToken(response, tokenDto.getAccessToken());
+        jwtProvider.setCookieRefreshToken(response, tokenDto.getRefreshToken());
 
         return TokenResponseDto.builder()
             .accessToken(tokenDto.getAccessToken())

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
@@ -50,10 +50,10 @@ public class MemberServiceImpl implements MemberService {
 
         TokenDto tokenDto = jwtProvider.generateJwtToken(member.getEmail());
 
-        if (refreshTokenRepository.findByKey(member.getEmail()).isPresent()) {
-            refreshTokenRepository.deleteByKey(member.getEmail());
+        if (refreshTokenRepository.findById(member.getEmail()).isPresent()) {
+            refreshTokenRepository.deleteById(member.getEmail());
         }
-        refreshTokenRepository.save(new RefreshToken(member.getEmail(), tokenDto.getRefreshToken()));
+        refreshTokenRepository.save(new RefreshToken(member.getEmail(), tokenDto.getRefreshToken(), jwtProvider.getRefreshTokenExpiredTime()));
 
         return TokenResponseDto.builder()
             .accessToken(tokenDto.getAccessToken())
@@ -77,8 +77,8 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public void deleteMember(String email) {
         memberRepository.deleteById(memberRepository.findByEmail(email).getId());
-        if (refreshTokenRepository.findByKey(email).isPresent()) {
-            refreshTokenRepository.deleteByKey(email);
+        if (refreshTokenRepository.findById(email).isPresent()) {
+            refreshTokenRepository.deleteById(email);
         }
     }
 
@@ -94,7 +94,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void logout(String email) {
-        refreshTokenRepository.deleteByKey(email);
+        refreshTokenRepository.deleteById(email);
     }
 
     @Override

--- a/src/main/resources/secret.yml
+++ b/src/main/resources/secret.yml
@@ -1,4 +1,0 @@
-jwt:
-  secretKey : 44LRhp5SLaazMmuastyRW6hR323scRALl9Qspzz2tl0gkeC8H9l25jIPjBSikMJymrnzxTw6I7yFhekBdMUprETSMnA9Ema4uDOYYPG2veMGuhd4owN4riT6XjWndSQPdNdE
-  accessExpirationTime: 1800
-  refreshExpirationTime: 1209600


### PR DESCRIPTION
## ✅ 변경사항
- ab4fcd4af6b374e6d923907a49917c3689436be1 : Refresh  Token Rotate 기법 적용으로 보안성을 향상했습니다.
- 7abca6c9a96139297805baf66da1a6d8ca18d2fe : Refresh Token을 서버에서 쿠키로 바로 저장하도록 변경했습니다.
- 4f13538728cea8942ec63150070d3e07c7691104 : Refresh Token을 인메모리 저장소인 Redis에 저장하도록 변경했습니다.
- de42f12811658b990a910506ab76685e705c78a6 : 프로젝트 빌드 시 이전 테스트에서 사용했던 redis 데이터를 모두 flush하여 초기화하도록 변경했습니다.
- f2ab00245e53f09682bae686cf05b72b2152477c : 로그인 시 swagger에서도 쿠키에 토큰이 저장되도록 설정했습니다.
- ad8e8ccc4d89b4d0709bae1dac7980c2629272f8 : 기존 로그아웃 방식에서 쿠키 저장방식에 맞는 로그아웃 방식으로 변경했습니다. 로그아웃 시에는 쿠키의 모든 토큰이 사라지고 Redis에 저장된 토큰도 제거됩니다.