### PR TITLE
[Refactor] 신고 엔티티 외래키 추가

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/Report.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/Report.java
@@ -48,17 +48,17 @@ public class Report extends BaseEntity {
     @Column
     private String reason;
 
-    public static Report toEntity(ReportRequestDto requestDto, Member reporter, Member reported, String opinContent) {
+    public static Report toEntity(ReportRequestDto requestDto, Member reporter, ReportPK reportPK, Opin opin) {
         return Report.builder()
-            .reportPK(new ReportPK(reporter.getId(), reported.getId()))
+            .reportPK(reportPK)
             .reporter(reporter)
-            .reported(reported)
+            .reported(opin.getVote().getMember())
             .type(requestDto.getType())
             .reason(
-                ! requestDto.getType().equals(ReportType.ETC)
-                ? requestDto.getType().getReason()
-                : requestDto.getReason())
-            .content(opinContent)
+                !requestDto.getType().equals(ReportType.ETC)
+                    ? requestDto.getType().getReason()
+                    : requestDto.getReason())
+            .content(opin.getContent())
             .build();
     }
 }

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/Report.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/Report.java
@@ -3,15 +3,15 @@ package com.HowBaChu.howbachu.domain.entity;
 import com.HowBaChu.howbachu.domain.base.BaseEntity;
 import com.HowBaChu.howbachu.domain.constants.ReportType;
 import com.HowBaChu.howbachu.domain.dto.report.ReportRequestDto;
+import com.HowBaChu.howbachu.domain.entity.embedded.ReportPK;
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,16 +25,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @EmbeddedId
+    private ReportPK reportPK;
 
-    @ManyToOne
+    @ManyToOne(optional = false)
     @JoinColumn(name = "reporter_id")
+    @MapsId("reporterId")
     private Member reporter;
 
-    @ManyToOne
+    @ManyToOne(optional = false)
     @JoinColumn(name = "reported_id")
+    @MapsId("reportedId")
     private Member reported;
 
     @Enumerated(EnumType.STRING)
@@ -49,6 +50,7 @@ public class Report extends BaseEntity {
 
     public static Report toEntity(ReportRequestDto requestDto, Member reporter, Member reported, String opinContent) {
         return Report.builder()
+            .reportPK(new ReportPK(reporter.getId(), reported.getId()))
             .reporter(reporter)
             .reported(reported)
             .type(requestDto.getType())

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/embedded/ReportPK.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/embedded/ReportPK.java
@@ -1,0 +1,17 @@
+package com.HowBaChu.howbachu.domain.entity.embedded;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportPK implements Serializable {
+    @Column(name = "reporter_id")
+    private Long reporterId;
+    @Column(name = "reported_id")
+    private Long reportedId;
+}

--- a/src/main/java/com/HowBaChu/howbachu/exception/ErrorResponse.java
+++ b/src/main/java/com/HowBaChu/howbachu/exception/ErrorResponse.java
@@ -1,20 +1,17 @@
 package com.HowBaChu.howbachu.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 
 @Data
 @Builder
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
-    private int status;
-    private String message;
     private HttpStatus httpStatus;
+    private String message;
 
     public ErrorResponse(HttpStatus status, String message) {
         this.httpStatus = status;

--- a/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
+++ b/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
@@ -37,9 +37,12 @@ public enum ErrorCode {
     /* TOPIC */
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "토픽 정보가 존재하지 않습니다."),
 
-    /* LIKES*/
+    /* LIKES */
     LIKES_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 정보가 존재하지 않습니다."),
-    LIKES_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "이미 좋아요 정보가 있습니다.");
+    LIKES_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "이미 좋아요 정보가 있습니다."),
+
+    /* REPORT */
+    ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "이미 신고한 사용자 입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/HowBaChu/howbachu/repository/ReportRepository.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/ReportRepository.java
@@ -2,10 +2,11 @@ package com.HowBaChu.howbachu.repository;
 
 import com.HowBaChu.howbachu.domain.entity.Member;
 import com.HowBaChu.howbachu.domain.entity.Report;
+import com.HowBaChu.howbachu.domain.entity.embedded.ReportPK;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, ReportPK> {
 
     List<Report> findByReported(Member reported);
 }


### PR DESCRIPTION
## ✅ 구현 기능
- 7ce8b8b967e9198cef27b043eb3314e46950f499 : 신고 엔티티의 아이디를 신고인과 피신고인을 외래키로 사용하는 복합키로 변경하였습니다. 이에 따라 중복 신고에 대한 예방을 강화했습니다.
- 1f983a1dce604d78ab10e891af2ad140b52feef2 : 중복 신고 시 익셉션을 터뜨리도록 설정했습니다.
- 79c5e3da67b0ce484419b1c38c04e5bc106a72a5 : Error Response에 불필요한 status 컬럼을 제거했습니다.