### PR TITLE
[Feature] 회원가입시 상태메시지 입력 제거

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/member/MemberRequestDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/member/MemberRequestDto.java
@@ -33,10 +33,6 @@ public class MemberRequestDto {
         @MBTIValid(enumClass = MBTI.class)
         private MBTI mbti;
 
-        @Schema(description = "상태메세지", example = "testStatusMessage")
-        @StatusMessageValid
-        private String statusMessage;
-
         public void encodePassword(String encoded) {
             this.password = encoded;
         }

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/Member.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/Member.java
@@ -62,7 +62,6 @@ public class Member extends BaseEntity {
             .password(requestDto.getPassword())
             .username(requestDto.getUsername())
             .mbti(requestDto.getMbti())
-            .statusMessage(requestDto.getStatusMessage())
             .isDeleted(false)
             .build();
     }


### PR DESCRIPTION
- 회원가입 진행 시 상태메시지를 필수로 입력해야 하던 부분을 삭제했습니다. 
- 이제 회원가입시에 입력하지 않고 회원정보 수정에서만 입력할 수 있습니다.

close #99 