### PR TITLE
[Fix] Cookie NP 해결

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/HowBaChu/howbachu/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.HowBaChu.howbachu.exception;
 
 import com.HowBaChu.howbachu.exception.constants.ErrorCode;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<?> handlerException(Exception e) {
         log.error("Unexpected_Exception : " + e.getMessage());
+        log.error("Unexpected_Exception : " + Arrays.toString(e.getStackTrace()));
         return ErrorCode.UNEXPECTED_EXCEPTION.toResponse(null);
     }
 }

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
@@ -159,14 +159,19 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private String resolveTokenFromCookie(HttpServletRequest request, String tokenType) {
-        for (Cookie cookie : request.getCookies()) {
-            if (!tokenType.equals(cookie.getName())) {
-                continue;
-            }
-            return cookie.getValue();
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return null;
         }
+
+        for (Cookie cookie : cookies) {
+            if (tokenType.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+
         return null;
     }
-
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: dev
+    active: prod
     include:
       - s3
       - mail


### PR DESCRIPTION
Request에 Cookie가 없을 시 request.getCookies()가 쿠키를 불러오지 못해 발생하는 에러를 해결했습니다. cookie가 없으면 바로 null을 반환하도록 변경했습니다.

BREAKING CHANGE:
앞으로 UNEXPECTED EXCEPTION에 대해 서버 로그로 추적할 수 있도록 로그 정책을 수정했습니다,