### PR TITLE
Feature/#108 opin owner identifier

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/controller/LikesController.java
+++ b/src/main/java/com/HowBaChu/howbachu/controller/LikesController.java
@@ -1,13 +1,19 @@
 package com.HowBaChu.howbachu.controller;
 
 import com.HowBaChu.howbachu.domain.constants.ResponseCode;
-import com.HowBaChu.howbachu.domain.dto.likes.LikesRequestDto;
+import com.HowBaChu.howbachu.exception.CustomException;
+import com.HowBaChu.howbachu.exception.constants.ErrorCode;
 import com.HowBaChu.howbachu.service.LikesService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,17 +22,21 @@ public class LikesController {
 
     private final LikesService likesService;
 
-    @PostMapping
-    public ResponseEntity<?> addLikes(@RequestParam("opinId") Long opinId,
-                                      @ApiIgnore Authentication authentication) {
-        return ResponseCode.LIKES_ADD.toResponse(
-            likesService.addLikes(authentication.getName(), opinId));
+    private String loggedInEmail() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+            .map(Authentication::getName)
+            .orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND)
+            );
     }
 
-    @DeleteMapping
-    public ResponseEntity<?> cancelLikes(@RequestBody LikesRequestDto requestDto,
-                                         @ApiIgnore Authentication authentication) {
-        return ResponseCode.LIKES_CANCEL.toResponse(
-            likesService.cancelLikes(authentication.getName(), requestDto.getOpinId()));
+    @PostMapping
+    public ResponseEntity<?> toggleLikes(@RequestParam("opinId") Long opinId) {
+        /* 로그인한 회원의 이메일 */
+        String email = loggedInEmail();
+        return likesService.checkDuplicateLike(email, opinId)
+            ? ResponseCode.LIKES_CANCEL.toResponse(likesService.cancelLikes(email, opinId))
+            : ResponseCode.LIKES_ADD.toResponse(likesService.addLikes(email, opinId));
     }
+
 }

--- a/src/main/java/com/HowBaChu/howbachu/controller/OpinController.java
+++ b/src/main/java/com/HowBaChu/howbachu/controller/OpinController.java
@@ -6,15 +6,7 @@ import com.HowBaChu.howbachu.service.OpinService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
@@ -26,39 +18,39 @@ public class OpinController {
 
     @PostMapping
     public ResponseEntity<?> postOpin(@RequestBody OpinRequestDto requestDto,
-        @ApiIgnore Authentication authentication) {
-        return ResponseCode.OPIN_SAVE.toResponse(
-            opinService.createOpin(requestDto, authentication.getName(), requestDto.getParentId()));
+                                      @ApiIgnore Authentication authentication) {
+        return ResponseCode.OPIN_SAVE.toResponse(opinService.createOpin(requestDto, authentication.getName(), requestDto.getParentId()));
     }
 
     @GetMapping
-    public ResponseEntity<?> listOpin(@RequestParam(name = "page", defaultValue = "0") int page) {
-        return ResponseCode.OPIN_LIST.toResponse(opinService.getOpinList(page));
+    public ResponseEntity<?> listOpin(@RequestParam(name = "page", defaultValue = "0") int page,
+                                      @ApiIgnore Authentication authentication) {
+        return ResponseCode.OPIN_LIST.toResponse(opinService.getOpinList(page, authentication.getName()));
     }
 
     @GetMapping(value = "/{id}")
-    public ResponseEntity<?> listOpin(@PathVariable("id") String id) {
-        return ResponseCode.OPIN_LIST.toResponse(opinService.getOpinThread(Long.parseLong(id)));
+    public ResponseEntity<?> listOpin(@PathVariable("id") Long id,
+                                      @ApiIgnore Authentication authentication) {
+        return ResponseCode.OPIN_LIST.toResponse(opinService.getOpinThread(id, authentication.getName()));
     }
 
     @PatchMapping(value = "/{id}")
     public ResponseEntity<?> updateOpin(@PathVariable("id") String id,
-        @RequestBody OpinRequestDto requestDto, @ApiIgnore Authentication authentication) {
-        return ResponseCode.OPIN_UPDATE.toResponse(
-            opinService.updateOpin(requestDto, Long.parseLong(id), authentication.getName()));
+                                        @RequestBody OpinRequestDto requestDto,
+                                        @ApiIgnore Authentication authentication) {
+        return ResponseCode.OPIN_UPDATE.toResponse(opinService.updateOpin(requestDto, Long.parseLong(id), authentication.getName()));
     }
 
-    @DeleteMapping(value = "/{id}")
-    public ResponseEntity<?> deleteOpin(@PathVariable("id") String id,
-        @ApiIgnore Authentication authentication) {
-        return ResponseCode.OPIN_DELETE.toResponse(
-            opinService.removeOpin(Long.parseLong(id), authentication.getName()));
+    @DeleteMapping
+    public ResponseEntity<?> deleteOpin(@RequestParam("opinId") Long opinId,
+                                        @ApiIgnore Authentication authentication) {
+        return ResponseCode.OPIN_DELETE.toResponse(opinService.removeOpin(opinId, authentication.getName()));
     }
 
-    @GetMapping(value = "/member")
-    public ResponseEntity<?> listMyOpin(@RequestParam(name = "id") Long memberId,
-        @RequestParam(name = "page", defaultValue = "0") int page) {
-        return ResponseCode.OPIN_LIST.toResponse(opinService.getOpinListForMember(memberId, page));
+    @GetMapping(value = "/my")
+    public ResponseEntity<?> listMyOpin(@RequestParam(name = "page", defaultValue = "0") int page,
+                                        @ApiIgnore Authentication authentication) {
+        return ResponseCode.OPIN_LIST.toResponse(opinService.getMyOpinList(page, authentication.getName()));
     }
 
 }

--- a/src/main/java/com/HowBaChu/howbachu/controller/VoteController.java
+++ b/src/main/java/com/HowBaChu/howbachu/controller/VoteController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 @Slf4j
@@ -27,6 +24,11 @@ public class VoteController {
         @RequestBody VoteRequestDto requestDto, HttpServletResponse response) {
         return ResponseCode.VOTING_SUCCESS.toResponse(
             voteService.voting(requestDto, authentication.getName(), response));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getVotingStatus(@ApiIgnore Authentication authentication) {
+        return ResponseCode.VOTING_SUCCESS.toResponse(voteService.getVotingStatus(authentication.getName()));
     }
 
 }

--- a/src/main/java/com/HowBaChu/howbachu/domain/constants/ResponseCode.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/constants/ResponseCode.java
@@ -15,13 +15,13 @@ public enum ResponseCode {
     OPIN_LIST(HttpStatus.OK, "200", "댓글 조회 성공"),
     OPIN_CHILD_LIST(HttpStatus.OK, "200", "대댓글 조회 성공"),
     OPIN_SAVE(HttpStatus.CREATED, "201", "댓글 등록 성공"),
-    OPIN_UPDATE(HttpStatus.NO_CONTENT, "204", "댓글 수정 성공"),
-    OPIN_DELETE(HttpStatus.NO_CONTENT, "204", "댓글 삭제 성공"),
+    OPIN_UPDATE(HttpStatus.OK, "200", "댓글 수정 성공"),
+    OPIN_DELETE(HttpStatus.OK, "200", "댓글 삭제 성공"),
 
     /*AUTH*/
     MEMBER_SAVE(HttpStatus.CREATED, "201", "회원가입 성공"),
     MEMBER_LOGIN(HttpStatus.OK, "200", "로그인 성공"),
-    MEMBER_LOGOUT(HttpStatus.NO_CONTENT, "204", "로그아웃 성공"),
+    MEMBER_LOGOUT(HttpStatus.OK, "200", "로그아웃 성공"),
     VERIFICATION_SEND(HttpStatus.OK, "200", "인증메일을 전송하였습니다."),
     VERIFICATION_SUCCESS(HttpStatus.OK, "200", "인증에 성공했습니다."),
     VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "401", "인증에 실패했습니다."),
@@ -29,17 +29,17 @@ public enum ResponseCode {
     /* MEMBER */
     MEMBER_DETAIL(HttpStatus.OK, "200", "회원정보 불러오기 성공"),
     MEMBER_UPDATE(HttpStatus.OK, "200", "회원정보 수정 성공"),
-    MEMBER_DELETE(HttpStatus.NO_CONTENT, "204", "회원정보 삭제 성공"),
+    MEMBER_DELETE(HttpStatus.OK, "200", "회원정보 삭제 성공"),
     MEMBER_EXISTS(HttpStatus.OK, "200", "회원존재 여부 조회 성공"),
     AVATAR_UPLOAD(HttpStatus.OK, "200", "이미지 업로드 성공"),
-    AVATAR_DELETE(HttpStatus.NO_CONTENT, "204", "이미지 삭제 성공"),
+    AVATAR_DELETE(HttpStatus.OK, "200", "이미지 삭제 성공"),
     PASSWORD_CORRECT(HttpStatus.OK, "200", "기존 비밀번호가 일치합니다."),
     PASSWORD_DISCORD(HttpStatus.BAD_REQUEST, "400", "기존 비밀번호가 틀렸습니다."),
 
     /* VOTE */
     VOTING_SUCCESS(HttpStatus.CREATED, "201", "투표 성공"),
-    VOTING_UPDATE(HttpStatus.NO_CONTENT, "204", "투표 수정 성공"),
-    VOTING_DELETE(HttpStatus.NO_CONTENT, "204", "투표 취소 성공"),
+    VOTING_UPDATE(HttpStatus.OK, "200", "투표 수정 성공"),
+    VOTING_DELETE(HttpStatus.OK, "200", "투표 취소 성공"),
 
     /* REPORT */
     REPORT_SAVE(HttpStatus.CREATED, "201", "신고 성공"),
@@ -51,7 +51,7 @@ public enum ResponseCode {
 
     /* LIKES */
     LIKES_ADD(HttpStatus.CREATED, "201", "좋아요 추가 성공"),
-    LIKES_CANCEL(HttpStatus.NO_CONTENT, "204", "좋아요 취소 성공"),
+    LIKES_CANCEL(HttpStatus.OK, "200", "좋아요 취소 성공"),
 
     /* SEARCH */
     SEARCH_SUCCESS(HttpStatus.OK, "200", "검색 성공");

--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/opin/OpinResponseDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/opin/OpinResponseDto.java
@@ -17,5 +17,6 @@ public class OpinResponseDto {
     private String nickname;
     private String content;
     private int likeCnt;
+    private boolean isOwner;
 
 }

--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/vote/VoteResponseDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/vote/VoteResponseDto.java
@@ -1,0 +1,11 @@
+package com.HowBaChu.howbachu.domain.dto.vote;
+
+import com.HowBaChu.howbachu.domain.constants.Selection;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoteResponseDto {
+    private Selection status;
+}

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/Opin.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/Opin.java
@@ -1,6 +1,7 @@
 package com.HowBaChu.howbachu.domain.entity;
 
 import com.HowBaChu.howbachu.domain.base.BaseEntity;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -12,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +27,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE opin SET is_deleted = true WHERE opin_id = ? OR report_cnt >= ReportCriteria.OPIN_SUSPENSION_COUNT.getCount()")
+@SQLDelete(sql = "UPDATE opin SET is_deleted = TRUE WHERE opin_id = ?")
 @Where(clause = "is_deleted != true")
 public class Opin extends BaseEntity {
 
@@ -100,7 +102,6 @@ public class Opin extends BaseEntity {
     public void updateContent(String content) {
         this.content = content;
     }
-
 
     public void addLikes() {
         this.likeCnt++;

--- a/src/main/java/com/HowBaChu/howbachu/repository/OpinRepository.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/OpinRepository.java
@@ -2,12 +2,7 @@ package com.HowBaChu.howbachu.repository;
 
 import com.HowBaChu.howbachu.domain.entity.Opin;
 import com.HowBaChu.howbachu.repository.custom.OpinRepositoryCustom;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface OpinRepository extends JpaRepository<Opin, Long>, OpinRepositoryCustom {
-    @Query("SELECT o from Opin o JOIN FETCH o.vote v JOIN FETCH v.member m WHERE o.id = :id AND m.email = :email")
-    Optional<Opin> findByOpinIdAndEmail(@Param("id") Long opinId, @Param("email") String email);
 }

--- a/src/main/java/com/HowBaChu/howbachu/repository/custom/OpinRepositoryCustom.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/custom/OpinRepositoryCustom.java
@@ -3,25 +3,38 @@ package com.HowBaChu.howbachu.repository.custom;
 
 import com.HowBaChu.howbachu.domain.dto.opin.OpinResponseDto;
 import com.HowBaChu.howbachu.domain.dto.search.SearchResultResponseDto;
+
 import java.util.List;
+
+import com.HowBaChu.howbachu.domain.entity.Opin;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OpinRepositoryCustom {
+
+    /* 단건 Opin 조회 - 삭제용(opinId, email )*/
+    Opin fetchOpinByIdAndEmail(Long opinId, String email);
     /* 부모 댓글 검색 결과 */
     List<SearchResultResponseDto.ParentsOpinSearchResponseDto> fetchParentOpinSearch(String condition);
+
     /* 자식 댓글 검색 결과 */
     List<SearchResultResponseDto.ChildOpinSearchResponseDto> fetchChildOpinSearch(String condition);
-     /* 부모 댓글 검색 결과 - 페이징 적용 <더보기> */
+
+    /* 부모 댓글 검색 결과 - 페이징 적용 <더보기> */
     Page<SearchResultResponseDto.ParentsOpinSearchResponseDto> fetchParentOpinSearch(String condition, Pageable pageable);
+
     /* 자식 댓글 검색 결과 - 페이징 적용 <더보기> */
     Page<SearchResultResponseDto.ChildOpinSearchResponseDto> fetchChildOpinSearch(String condition, Pageable pageable);
+
     /* 자식 댓글 리스트 조회 */
-    List<OpinResponseDto> fetchOpinChildList(Long parentId);
+    List<OpinResponseDto> fetchChildOpinList(Long parentId, String email);
+
     /* 부모 댓글 단건 조회 */
-    OpinResponseDto fetchParentOpin(Long opinId);
+    OpinResponseDto fetchParentOpin(Long opinId, String email);
+
     /* 댓글 조회 */
-    Page<OpinResponseDto> fetchParentOpinList(int page);
+    Page<OpinResponseDto> fetchParentOpinList(int page, String email);
+
     /* 특정 회원이 쓴 댓글 조회 -> 내가 쓴 댓글 포함 */
-    Page<OpinResponseDto> fetchOpinListByMemberId(Long memberId, int page);
+    Page<OpinResponseDto> fetchMyOpinList(int page, String email);
 }

--- a/src/main/java/com/HowBaChu/howbachu/repository/custom/VoteRepositoryCustom.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/custom/VoteRepositoryCustom.java
@@ -2,10 +2,9 @@ package com.HowBaChu.howbachu.repository.custom;
 
 
 import com.HowBaChu.howbachu.domain.entity.Vote;
-import java.util.Optional;
 
 public interface VoteRepositoryCustom {
-    boolean findVoteByTopicAndMember(Long topicId, Long memberId);
+    boolean fetchVoteByTopicAndMember(Long topicId, Long memberId);
 
-    Optional<Vote> findVoteByEmail(String email);
+    Vote fetchVoteByEmail(String email);
 }

--- a/src/main/java/com/HowBaChu/howbachu/repository/impl/VoteRepositoryImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/repository/impl/VoteRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.HowBaChu.howbachu.repository.impl;
 
-import static com.HowBaChu.howbachu.domain.entity.QVote.vote;
-
 import com.HowBaChu.howbachu.domain.entity.Vote;
+import com.HowBaChu.howbachu.exception.CustomException;
+import com.HowBaChu.howbachu.exception.constants.ErrorCode;
 import com.HowBaChu.howbachu.repository.Support.Querydsl4RepositorySupport;
 import com.HowBaChu.howbachu.repository.custom.VoteRepositoryCustom;
+
 import java.util.Optional;
+
+import static com.HowBaChu.howbachu.domain.entity.QMember.member;
+import static com.HowBaChu.howbachu.domain.entity.QVote.vote;
 
 public class VoteRepositoryImpl extends Querydsl4RepositorySupport implements VoteRepositoryCustom {
 
@@ -14,19 +18,21 @@ public class VoteRepositoryImpl extends Querydsl4RepositorySupport implements Vo
     }
 
     @Override
-    public boolean findVoteByTopicAndMember(Long topicId, Long memberId) {
-        return selectFrom(vote)
-            .where(vote.topic.id.eq(topicId).and(vote.member.id.eq(memberId)))
-            .fetchOne() != null;
+    public boolean fetchVoteByTopicAndMember(Long topicId, Long memberId) {
+        return Optional.ofNullable(selectFrom(vote)
+                .where(vote.topic.id.eq(topicId).and(vote.member.id.eq(memberId)))
+                .fetchOne())
+            .isPresent();
     }
 
     @Override
-    public Optional<Vote> findVoteByEmail(String email) {
+    public Vote fetchVoteByEmail(String email) {
         return Optional.ofNullable(
             selectFrom(vote)
-                .where(vote.member.email.eq(email))
+                .leftJoin(vote.member, member).fetchJoin()
+                .where(member.email.eq(email))
                 .fetchOne()
-        );
+        ).orElseThrow(() -> new CustomException(ErrorCode.VOTE_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/HowBaChu/howbachu/service/LikesService.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/LikesService.java
@@ -1,6 +1,9 @@
 package com.HowBaChu.howbachu.service;
 
 public interface LikesService {
-    Long addLikes(String email, Long opineId);
-    Long cancelLikes(String email, Long opineId);
+    Long addLikes(String email, Long opinId);
+
+    Long cancelLikes(String email, Long opinId);
+
+    boolean checkDuplicateLike(String email, Long opinId);
 }

--- a/src/main/java/com/HowBaChu/howbachu/service/OpinService.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/OpinService.java
@@ -8,10 +8,16 @@ import org.springframework.data.domain.Page;
 
 public interface OpinService {
     Long createOpin(OpinRequestDto requestDto, String email, Long parentId);
-    Page<OpinResponseDto> getOpinList(int page);
-    OpinThreadResponseDto getOpinThread(Long parentId);
+
+    Page<OpinResponseDto> getOpinList(int page, String email);
+
+    OpinThreadResponseDto getOpinThread(Long parentId, String email);
+
     Long removeOpin(Long opinId, String email);
+
     Long updateOpin(OpinRequestDto requestDto, Long opinId, String email);
+
     Opin getOpin(Long opinId, String email);
-    Page<OpinResponseDto> getOpinListForMember(Long memberId, int page);
+
+    Page<OpinResponseDto> getMyOpinList(int page, String email);
 }

--- a/src/main/java/com/HowBaChu/howbachu/service/VoteService.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/VoteService.java
@@ -2,8 +2,12 @@ package com.HowBaChu.howbachu.service;
 
 
 import com.HowBaChu.howbachu.domain.dto.vote.VoteRequestDto;
+import com.HowBaChu.howbachu.domain.dto.vote.VoteResponseDto;
+
 import javax.servlet.http.HttpServletResponse;
 
 public interface VoteService {
     Long voting(VoteRequestDto requestDto, String email, HttpServletResponse response);
+
+    VoteResponseDto getVotingStatus(String name);
 }

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MemberServiceImpl.java
@@ -13,17 +13,17 @@ import com.HowBaChu.howbachu.exception.constants.ErrorCode;
 import com.HowBaChu.howbachu.jwt.JwtProvider;
 import com.HowBaChu.howbachu.repository.MemberRepository;
 import com.HowBaChu.howbachu.repository.RefreshTokenRepository;
-import com.HowBaChu.howbachu.repository.VoteRepository;
 import com.HowBaChu.howbachu.service.MemberService;
 import com.HowBaChu.howbachu.utils.CookieUtil;
-import java.util.Optional;
-import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -37,9 +37,7 @@ public class MemberServiceImpl implements MemberService {
     private final String VOTE = "Vote";
     private final String PROFILE_URL = "profile";
 
-    private final VoteRepository voteRepository;
-    private final MemberRepository
-        memberRepository;
+    private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
@@ -74,9 +72,6 @@ public class MemberServiceImpl implements MemberService {
         // 리프레쉬 토큰 외에는 세션 토큰.
         cookieUtil.setCookie(response, REFRESH_TOKEN, tokenDto.getRefreshToken(), jwtProvider.getRefreshTokenExpiredTime());
         cookieUtil.setCookie(response, ACCESS_TOKEN, tokenDto.getAccessToken());
-        cookieUtil.setCookie(response, MEMBER_ID, String.valueOf(member.getId()));
-        voteRepository.findVoteByEmail(member.getEmail())
-            .ifPresent(value -> cookieUtil.setCookie(response, VOTE, value.getSelection().toString()));
 
         return TokenResponseDto.builder()
             .accessToken(tokenDto.getAccessToken())
@@ -127,7 +122,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public MemberResponseDto uploadAvatar(String email, MultipartFile image){
+    public MemberResponseDto uploadAvatar(String email, MultipartFile image) {
         Member member = findMemberByEmail(email);
         member.uploadAvatar(awsFileManager.upload(PROFILE_URL, image));
 

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/OpinServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/OpinServiceImpl.java
@@ -10,7 +10,9 @@ import com.HowBaChu.howbachu.exception.constants.ErrorCode;
 import com.HowBaChu.howbachu.repository.OpinRepository;
 import com.HowBaChu.howbachu.repository.VoteRepository;
 import com.HowBaChu.howbachu.service.OpinService;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -28,9 +30,7 @@ public class OpinServiceImpl implements OpinService {
     @Transactional
     public Long createOpin(OpinRequestDto requestDto, String email, Long parentId) {
 
-        Vote vote = voteRepository.findVoteByEmail(email).orElseThrow(
-            () -> new CustomException(ErrorCode.VOTE_NOT_FOUND)
-        );
+        Vote vote = voteRepository.fetchVoteByEmail(email);
 
         Opin opin;
         if (parentId == null) {
@@ -47,14 +47,14 @@ public class OpinServiceImpl implements OpinService {
     }
 
     @Override
-    public Page<OpinResponseDto> getOpinList(int page) {
-        return opinRepository.fetchParentOpinList(page);
+    public Page<OpinResponseDto> getOpinList(int page, String email) {
+        return opinRepository.fetchParentOpinList(page, email);
     }
 
     @Override
-    public OpinThreadResponseDto getOpinThread(Long parentId) {
-        OpinResponseDto parentOpin = opinRepository.fetchParentOpin(parentId);
-        List<OpinResponseDto> childOpinList = opinRepository.fetchOpinChildList(parentId);
+    public OpinThreadResponseDto getOpinThread(Long parentId, String email) {
+        OpinResponseDto parentOpin = opinRepository.fetchParentOpin(parentId, email);
+        List<OpinResponseDto> childOpinList = opinRepository.fetchChildOpinList(parentId, email);
         return new OpinThreadResponseDto(parentOpin, childOpinList);
     }
 
@@ -75,14 +75,12 @@ public class OpinServiceImpl implements OpinService {
 
     @Override
     public Opin getOpin(Long opinId, String email) {
-        return opinRepository.findByOpinIdAndEmail(opinId, email).orElseThrow(
-            () -> new CustomException(ErrorCode.OPIN_MISS_MATCH)
-        );
+        return opinRepository.fetchOpinByIdAndEmail(opinId, email);
     }
 
     @Override
-    public Page<OpinResponseDto> getOpinListForMember(Long memberId, int page) {
-        return opinRepository.fetchOpinListByMemberId(memberId, page);
+    public Page<OpinResponseDto> getMyOpinList(int page, String email) {
+        return opinRepository.fetchMyOpinList(page, email);
     }
 
 }

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/VoteServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/VoteServiceImpl.java
@@ -1,6 +1,7 @@
 package com.HowBaChu.howbachu.service.impl;
 
 import com.HowBaChu.howbachu.domain.dto.vote.VoteRequestDto;
+import com.HowBaChu.howbachu.domain.dto.vote.VoteResponseDto;
 import com.HowBaChu.howbachu.domain.entity.Member;
 import com.HowBaChu.howbachu.domain.entity.Topic;
 import com.HowBaChu.howbachu.domain.entity.Vote;
@@ -39,8 +40,13 @@ public class VoteServiceImpl implements VoteService {
         return voteRepository.save(Vote.of(requestDto, topic, member)).getId();
     }
 
+    @Override
+    public VoteResponseDto getVotingStatus(String email) {
+        return new VoteResponseDto(voteRepository.fetchVoteByEmail(email).getSelection());
+    }
+
     @Transactional(readOnly = true)
     public boolean hasAlreadyVoted(Long topicId, Long memberId) {
-        return voteRepository.findVoteByTopicAndMember(topicId, memberId);
+        return voteRepository.fetchVoteByTopicAndMember(topicId, memberId);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: dev
     include:
       - s3
       - mail


### PR DESCRIPTION
- [X] NO_CONTENT 로 설정할 시, 응답 코드 또한 반환이 안되기 때문에 모두 OK(200) 으로 수정.
- [X] 기존 쿠키로 투표 여부를 반환했던 것을 별도로 투표 여부 조회하는 기능을 추가 -> 추후에 성능 최적화를 위해 캐싱 적용 예정.
- [X] 리포지터리에서 데이터를 조회할 때 fetch* 로 통일.
- [X] boolean 타입으로 조회할 때, Optional 타입 및 isPresent() 메서드를 활용
- [X] 기존 코드의 문제는 좋아요 추가 및 삭제를 각각 POST, DELETE 메서드를 나누어서 API를 따로 호출해야하는 문제점 -> 하나의 메서드로 통일하여, 좋아요 여부를 확인하여 true 이면 삭제를, false 이면 추가하는 메서드를 호출하도록 수정.
- [X] 좋아요 여부 메서드를 boolean 타입으로 변경 및 분리
- [X] report_cnt >= ReportCriteria.OPIN_SUSPENSION_COUNT.getCount() 코드로 인해 Opin 이 삭제되지 않음. -> 로그를 해석해보면, 문법의 오류이거나 버전에 맞지 않은 SQL문법이라고 나타나기 때문에 추후에 문제 해결 후 다시 추가해야 함.
- [X] 전체적으로 SQL문을 Querydsl 로 통일해서 사용하기 위해, 불필요한 JPQL 코드는 삭제.
- [X] 기존 JPQL 로 작성되어 있던 id & email 을 통한 조회쿼리를 Querydsl 로 이전.
- [X] 모든 Opin 응답 DTO에 요청자에 따라서 해당 Opin 의 주인 여부를 확인할 수 있도록 속성을 추가.
- [X] 부분 코드 리팩토링.
- [X] `내가 쓴글 보기` 쿼리문 테스트 수행.
- [X] OpinController 부분 리팩토링.
- [X] 각각 API를 통한 조회와 Opin 주인 여부 판단은 데이터로부터 확인이 가능하기 때문에 불필요한 쿠키는 삭제.