### PR TITLE
[Test] Auth, Member 테스트 코드 리팩토링

### DIFF
--- a/src/main/java/com/HowBaChu/howbachu/config/SecurityConfig.java
+++ b/src/main/java/com/HowBaChu/howbachu/config/SecurityConfig.java
@@ -61,8 +61,8 @@ public class SecurityConfig {
                 "/api/v1/topic",
                 "/api/v1/auth/signup",
                 "/api/v1/auth/login",
-                "/api/v1/member/email/{email}/exists",
-                "/api/v1/member/username/{username}/exists",
+                "/api/v1/member/exists/email/{email}",
+                "/api/v1/member/exists/username/{username}",
                 "/api/v1/auth/mail-verification"
             ).permitAll()
             .anyRequest().authenticated();

--- a/src/main/java/com/HowBaChu/howbachu/controller/MemberController.java
+++ b/src/main/java/com/HowBaChu/howbachu/controller/MemberController.java
@@ -52,13 +52,13 @@ public class MemberController {
     }
 
     /*이메일 중복 검사*/
-    @GetMapping("/email/{email}/exists")
+    @GetMapping("/exists/email/{email}")
     public ResponseEntity<?> checkEmailDuplicate(@PathVariable String email) {
         return ResponseCode.MEMBER_EXISTS.toResponse(memberService.checkEmailDuplicate(email));
     }
 
     /*닉네임 중복 검사*/
-    @GetMapping("/username/{username}/exists")
+    @GetMapping("/exists/username/{username}")
     public ResponseEntity<?> checkUsernameDuplicate(@PathVariable String username) {
         return ResponseCode.MEMBER_EXISTS.toResponse(
             memberService.checkUsernameDuplicate(username));

--- a/src/main/java/com/HowBaChu/howbachu/domain/constants/MBTI.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/constants/MBTI.java
@@ -4,7 +4,9 @@ import com.HowBaChu.howbachu.exception.CustomException;
 import com.HowBaChu.howbachu.exception.constants.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.stream.Stream;
+import lombok.Getter;
 
+@Getter
 public enum MBTI {
     ISTJ, ISFJ, INFJ, INTJ, ISTP, ISFP, INFP, INTP,
     ESTP, ESFP, ENFP, ENTP, ESTJ, ESFJ, ENFJ, ENTJ;
@@ -15,5 +17,10 @@ public enum MBTI {
             .filter(c -> c.name().equals(code))
             .findAny()
             .orElseThrow(() -> new CustomException(ErrorCode.NONE_MATCHED_MBTI));
+    }
+
+    public static boolean isExists(String code) {
+        return Stream.of(MBTI.values())
+            .anyMatch(c -> c.name().equals(code));
     }
 }

--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/jwt/TokenDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/jwt/TokenDto.java
@@ -13,6 +13,13 @@ public class TokenDto {
     private String accessToken;
     private String refreshToken;
     private String key;
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }
 
 

--- a/src/main/java/com/HowBaChu/howbachu/domain/dto/member/MemberRequestDto.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/dto/member/MemberRequestDto.java
@@ -14,6 +14,8 @@ import lombok.NoArgsConstructor;
 
 public class MemberRequestDto {
 
+    private MemberRequestDto() {}
+
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
@@ -31,7 +33,7 @@ public class MemberRequestDto {
         private String username;
 
         @MBTIValid(enumClass = MBTI.class)
-        private MBTI mbti;
+        private String mbti;
 
         public void encodePassword(String encoded) {
             this.password = encoded;
@@ -65,7 +67,7 @@ public class MemberRequestDto {
         private String username;
 
         @MBTIValid(enumClass = MBTI.class)
-        private MBTI mbti;
+        private String mbti;
 
         @StatusMessageValid
         @Schema(description = "상태메세지", example = "testStatusMessageUpdated")

--- a/src/main/java/com/HowBaChu/howbachu/domain/entity/Member.java
+++ b/src/main/java/com/HowBaChu/howbachu/domain/entity/Member.java
@@ -62,7 +62,7 @@ public class Member extends BaseEntity {
             .email(requestDto.getEmail())
             .password(requestDto.getPassword())
             .username(requestDto.getUsername())
-            .mbti(requestDto.getMbti())
+            .mbti(MBTI.findByCode(requestDto.getMbti()))
             .isDeleted(false)
             .build();
     }
@@ -70,7 +70,7 @@ public class Member extends BaseEntity {
     public void update(MemberRequestDto.update requestDto) {
         this.password = requestDto.getPassword();
         this.username = requestDto.getUsername();
-        this.mbti = requestDto.getMbti();
+        this.mbti = MBTI.findByCode(requestDto.getMbti());
         this.statusMessage = requestDto.getStatusMessage();
     }
 
@@ -88,4 +88,5 @@ public class Member extends BaseEntity {
         if (!(o instanceof Member )) return false;
         return id != null && id.equals(((Member) o).getId());
     }
+
 }

--- a/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
+++ b/src/main/java/com/HowBaChu/howbachu/exception/constants/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "401", "로그인 정보 형식이 올바르지 않습니다."),
     INVALID_TOKEN_STRUCTURE(HttpStatus.UNAUTHORIZED, "401", "로그인 정보가 올바르지 않습니다."),
     MODIFIED_TOKEN_DETECTED(HttpStatus.UNAUTHORIZED, "401", "로그인 정보가 변경되었습니다."),
-    EMAIL_VERIFICATION_FAILED(HttpStatus.FORBIDDEN, "403", "인증에 실패하였습니다."),
+    EMAIL_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "400", "이메일 인증에 실패하였습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "403", "토큰 정보가 만료되었습니다. 로그인이 필요합니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "401", "토큰이 존재하지 않습니다."),
 

--- a/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
+++ b/src/main/java/com/HowBaChu/howbachu/jwt/JwtFilter.java
@@ -52,8 +52,10 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private boolean isLoginRequest(HttpServletRequest request) {
+        log.info("request.getRequestURI() : {}", request.getRequestURI());
         return request.getRequestURI().equals("/api/v1/auth/login")
-            || request.getRequestURI().equals("/api/v1/auth/signup");
+            || request.getRequestURI().equals("/api/v1/auth/signup")
+            || request.getRequestURI().startsWith("/api/v1/member/exists");
     }
 
     private void handleTokens(String accessToken, String refreshToken, HttpServletRequest request,

--- a/src/main/java/com/HowBaChu/howbachu/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/HowBaChu/howbachu/service/impl/MailServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
@@ -35,7 +36,11 @@ public class MailServiceImpl implements MailService {
     public void sendMessage(String to) {
         MimeMessage message = createMessage(to);
         redisUtil.setDataExpire(verificationCode, to, expired);
-        javaMailSender.send(message);
+        try {
+            javaMailSender.send(message);
+        } catch (MailException e) {
+            throw new CustomException(ErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
     }
 
     @Override

--- a/src/main/java/com/HowBaChu/howbachu/validation/MBTI/MBTIValidator.java
+++ b/src/main/java/com/HowBaChu/howbachu/validation/MBTI/MBTIValidator.java
@@ -4,7 +4,7 @@ import com.HowBaChu.howbachu.domain.constants.MBTI;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-public class MBTIValidator implements ConstraintValidator<MBTIValid, MBTI> {
+public class MBTIValidator implements ConstraintValidator<MBTIValid, String> {
 
     @Override
     public void initialize(MBTIValid constraintAnnotation) {
@@ -12,7 +12,7 @@ public class MBTIValidator implements ConstraintValidator<MBTIValid, MBTI> {
     }
 
     @Override
-    public boolean isValid(MBTI value, ConstraintValidatorContext context) {
-        return value != null;
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return MBTI.isExists(value);
     }
 }

--- a/src/test/java/com/HowBaChu/howbachu/controller/AuthControllerTest.java
+++ b/src/test/java/com/HowBaChu/howbachu/controller/AuthControllerTest.java
@@ -1,126 +1,376 @@
 package com.HowBaChu.howbachu.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.HowBaChu.howbachu.domain.constants.MBTI;
-import com.HowBaChu.howbachu.domain.dto.jwt.TokenResponseDto;
-import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto;
-import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto.login;
-import com.HowBaChu.howbachu.repository.MemberRepository;
-import com.HowBaChu.howbachu.repository.RefreshTokenRepository;
-import com.HowBaChu.howbachu.service.MemberService;
+import com.HowBaChu.howbachu.domain.dto.jwt.TokenDto;
+import com.HowBaChu.howbachu.validation.LimitBound;
 import com.google.gson.Gson;
+import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.servlet.http.HttpServletResponse;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @ActiveProfiles("test")
-@SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@SpringBootTest
 class AuthControllerTest {
 
-    static {
-        System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
-    }
+    @Autowired
+    MockMvc mockMvc;
 
     @Autowired
-    private MemberService memberService;
-    @Autowired
-    private MockMvc mockMvc;
-    @Autowired
-    MemberRepository memberRepository;
-    @Autowired
-    RefreshTokenRepository refreshTokenRepository;
-    @Autowired
-    HttpServletResponse response;
+    Gson gson;
 
-    MemberRequestDto.signup memberSignupDto;
-    MemberRequestDto.login memberLoginDto;
-    String content;
-    Gson gson = new Gson();
+    MemberRequestTestDto memberSignupDto;
+    MemberLoginTestDto memberLoginDto;
+
+    String testEmail = "testEmail@howbachu.com";
+    String testPassword = "testPassword!123";
+    String testUsername = "testUsername";
+    String testMBTI = MBTI.INFP.name();
+
+    final String ACCESS_TOKEN = "Access-Token";
+    final String REFRESH_TOKEN = "Refresh-Token";
 
     @BeforeEach
     void init() {
-        memberSignupDto = new MemberRequestDto.signup("testEmail@naver.com", "testPassword!123", "testUsername",
-            MBTI.ENTJ);
-        memberLoginDto = new login("testEmail@naver.com", "testPassword!123");
+        memberSignupDto = new MemberRequestTestDto(testEmail, testPassword,
+            testUsername, testMBTI);
+        memberLoginDto = new MemberLoginTestDto(testEmail, testPassword);
+    }
+
+    @Nested
+    @DisplayName("회원가입 테스트")
+    class testRegister {
+
+        @Test
+        @DisplayName("정상적인 회원가입이 가능하다.")
+        void register_With_Normal_Columns() throws Exception {
+            //given
+
+            // when
+
+            // then
+            mockMvc.perform(
+                    post("/api/v1/auth/signup")
+                        .content(convertToJson(memberSignupDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        }
+
+        @Test
+        @DisplayName("이메일은 이메일 형식에 맞춰 입력해야 한다.")
+        void register_With_Bad_Email() throws Exception {
+            //given
+            String badEmail = testEmail.replace("@", "+");
+
+            // when
+            memberSignupDto.changeEmail(badEmail);
+
+            // then
+            mockMvc.perform(
+                    post("/api/v1/auth/signup")
+                        .content(convertToJson(memberSignupDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"1234567891011121314asbvb!!!!", "1a!"}, delimiter = ',')
+        @DisplayName("비밀번호는" + LimitBound.passwordMinLength + "자 이상 "
+            + LimitBound.passwordMaxLength + "자 이하로 입력해야 한다.")
+        void register_With_Bad_Password(String badPassword) throws Exception {
+            //given
+
+            // when
+            memberSignupDto.changePassword(badPassword);
+
+            // then
+            mockMvc.perform(
+                    post("/api/v1/auth/signup")
+                        .content(convertToJson(memberSignupDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"12345678", "abcdefgh", "!@#$%^&*"}, delimiter = ',')
+        @DisplayName("비밀번호는 영문, 숫자, 특수문자를 포함해야 한다.")
+        void register_With_Bad_Password2(String badPassword) throws Exception {
+            //given
+
+            // when
+            memberSignupDto.changePassword(badPassword);
+
+            // then
+            mockMvc.perform(
+                    post("/api/v1/auth/signup")
+                        .content(convertToJson(memberSignupDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"1", "1234567891011121314aabb"}, delimiter = ',')
+        @DisplayName("닉네임은" + LimitBound.userNameMinLength + "자 이상 "
+            + LimitBound.userNameMaxLength + "자 이하로 입력해야 한다.")
+        void register_With_Bad_Username(String badUsername) throws Exception {
+            //given
+
+            // when
+            memberSignupDto.changeUsername(badUsername);
+
+            // then
+            mockMvc.perform(
+                    post("/api/v1/auth/signup")
+                        .content(convertToJson(memberSignupDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"ESSP", "EFGH", "SPFJ", "ESJF"}, delimiter = ',')
+        @DisplayName("MBTI는 정확한 MBTI로 입력해야 한다.")
+        void register_With_Bad_MBTI(String badMBTI) throws Exception {
+            //given
+
+            // when
+            memberSignupDto.changeMBTI(badMBTI);
+
+            // then
+            mockMvc.perform(
+                    post("/api/v1/auth/signup")
+                        .content(convertToJson(memberSignupDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        }
 
     }
 
-    @Test
-    @DisplayName("회원가입 테스트 - 컨트롤러")
-    void register() throws Exception {
-        //given
-        content = gson.toJson(memberSignupDto);
+    @Nested
+    @DisplayName("로그인 테스트")
+    class loginTest {
 
-        //when
-        mockMvc.perform(
+        @BeforeEach
+        void init() throws Exception {
+            mockMvc.perform(
                 post("/api/v1/auth/signup")
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.responseCode").exists())
-            .andExpect(jsonPath("$.code").exists())
-            .andExpect(jsonPath("$.message").exists())
-            .andDo(print());
+                    .content(convertToJson(memberSignupDto))
+                    .contentType(MediaType.APPLICATION_JSON));
+        }
 
-        //then
-        assertThat(memberRepository.existsByEmail(memberSignupDto.getEmail())).isTrue();
+        @Test
+        @DisplayName("틀린 비밀번호로는 로그인할 수 없다.")
+        void login_With_Wrong_Password() throws Exception {
+            //given
+            String wrongPassword = testPassword.replace("!", "@");
+
+            //when
+            memberLoginDto.changePassword(wrongPassword);
+
+            //then
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .content(convertToJson(memberLoginDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("가입되지 않는 이메일로는 로그인할 수 없다.")
+        void login_With_Not_Exist_Email() throws Exception {
+            //given
+            String notExistEmail = testEmail.replace("test", "wrongTest");
+
+            //when
+            memberLoginDto.changeEmail(notExistEmail);
+
+            //then
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .content(convertToJson(memberLoginDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("정상적으로 로그인이 가능하다.")
+        void login_Success() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                        .content(convertToJson(memberLoginDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists())
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("정상적으로 로그아웃이 가능하다.")
+        void logout_Success() throws Exception {
+            //given
+            TokenDto tokenDto = new TokenDto();
+
+            //when
+            MockHttpServletResponse response = mockMvc.perform(post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberLoginDto)))
+                .andReturn().getResponse();
+
+            tokenDto.setAccessToken(response.getCookie(ACCESS_TOKEN).getValue());
+            tokenDto.setRefreshToken(response.getCookie(REFRESH_TOKEN).getValue());
+            //then
+            mockMvc.perform(
+                    post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                        .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isNoContent());
+        }
+
     }
 
-    @Test
-    @DisplayName("로그인 테스트 - 컨트롤러")
-    void login() throws Exception {
-        //given
-        memberSignupDto.encodePassword("testPassword!123");
-        memberService.signup(memberSignupDto);
-        content = gson.toJson(memberLoginDto);
-        //when
-        mockMvc.perform(
-                post("/api/v1/auth/login")
-                    .content(content)
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.accessToken").exists())
-            .andDo(print());
+    @Nested
+    @DisplayName("이메일 인증 테스트")
+    class mailVerificationTest {
 
-        //then
-//        assertThat(refreshTokenRepository.findByKey(memberSignupDto.getEmail())).isNotEqualTo(
-//            Optional.empty());
+        TokenDto tokenDto;
+
+        @BeforeEach
+        void init() throws Exception {
+            tokenDto = new TokenDto();
+
+            mockMvc.perform(
+                post("/api/v1/auth/signup")
+                    .content(convertToJson(memberSignupDto))
+                    .contentType(MediaType.APPLICATION_JSON));
+
+            MockHttpServletResponse response = mockMvc.perform(post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberLoginDto)))
+                .andReturn().getResponse();
+
+            tokenDto.setAccessToken(response.getCookie(ACCESS_TOKEN).getValue());
+            tokenDto.setRefreshToken(response.getCookie(REFRESH_TOKEN).getValue());
+        }
+
+        @Test
+        @DisplayName("이메일 형식에 맞지 않으면 인증 메일을 보낼 수 없다")
+        void verification_Mail_Send_With_Bad_Email() throws Exception {
+            //given
+            String badEmail = testEmail.replace("@", "+");
+
+            //when
+
+            //then
+            mockMvc.perform(
+                    post("/api/v1/auth/mail-verification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                        .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken()))
+                        .param("email", badEmail))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("정상적으로 인증 메일을 보낼 수 있다")
+        void verification_Mail_Send() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(
+                    post("/api/v1/auth/mail-verification")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("email", testEmail)
+                        .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                        .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
     }
 
-    @Test
-    @DisplayName("로그아웃 테스트 - 컨트롤러")
-    void logout() throws Exception {
-        //given
-        memberService.signup(memberSignupDto);
-        memberSignupDto.encodePassword("testPassword!123");
-        TokenResponseDto tokenResponseDto = memberService.login(memberLoginDto, response);
-
-        //when
-        mockMvc.perform(
-                post("/api/v1/auth/logout")
-                    .header("Authorization", tokenResponseDto.getAccessToken())
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andDo(print());
-
-        //then
-//        assertThat(refreshTokenRepository.findByKey(memberSignupDto.getEmail())).isEqualTo(
-//            Optional.empty());
+    private String convertToJson(Object content) {
+        return gson.toJson(content);
     }
+
+    private class MemberRequestTestDto {
+
+        private String email;
+        private String password;
+        private String username;
+        private String mbti;
+
+        public MemberRequestTestDto(String testEmail, String testPassword, String testUsername,
+            String testMBTI) {
+            this.email = testEmail;
+            this.password = testPassword;
+            this.username = testUsername;
+            this.mbti = testMBTI;
+        }
+
+        public void changeEmail(String email) {
+            this.email = email;
+        }
+
+        public void changePassword(String password) {
+            this.password = password;
+        }
+
+        public void changeUsername(String username) {
+            this.username = username;
+        }
+
+        public void changeMBTI(String mbti) {
+            this.mbti = mbti;
+        }
+
+    }
+
+    private class MemberLoginTestDto {
+
+        private String email;
+        private String password;
+
+        public MemberLoginTestDto(String email, String password) {
+            this.email = email;
+            this.password = password;
+        }
+
+        public void changeEmail(String email) {
+            this.email = email;
+        }
+
+        public void changePassword(String password) {
+            this.password = password;
+        }
+    }
+
+
 }

--- a/src/test/java/com/HowBaChu/howbachu/controller/MemberControllerTest.java
+++ b/src/test/java/com/HowBaChu/howbachu/controller/MemberControllerTest.java
@@ -1,29 +1,28 @@
 package com.HowBaChu.howbachu.controller;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.HowBaChu.howbachu.domain.constants.MBTI;
-import com.HowBaChu.howbachu.domain.dto.jwt.TokenResponseDto;
-import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto;
-import com.HowBaChu.howbachu.domain.dto.member.MemberRequestDto.login;
-import com.HowBaChu.howbachu.exception.CustomException;
-import com.HowBaChu.howbachu.repository.MemberRepository;
-import com.HowBaChu.howbachu.service.MemberService;
+import com.HowBaChu.howbachu.domain.dto.jwt.TokenDto;
+import com.HowBaChu.howbachu.validation.LimitBound;
 import com.google.gson.Gson;
+import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,129 +33,433 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class MemberControllerTest {
 
-    static {
-        System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
-    }
+    @Autowired
+    MockMvc mockMvc;
 
     @Autowired
-    private MemberService memberService;
-    @Autowired
-    private MockMvc mockMvc;
-    @Autowired
-    MemberRepository memberRepository;
+    Gson gson;
 
-    MemberRequestDto.signup memberSignupDto;
-    MemberRequestDto.login memberLoginDto;
-    TokenResponseDto tokenResponseDto;
-    String content;
+    MemberSingupTestDto memberSignupDto;
+    MemberLoginTestDto memberLoginDto;
+    TokenDto tokenDto;
+
+    String testEmail = "testEmail@howbachu.com";
+    String testPassword = "testPassword!123";
+    String testUsername = "testUsername";
+    String testMBTI = MBTI.INFP.name();
+    String testStatusMessage = "testStatusMessage";
+
+    final String ACCESS_TOKEN = "Access-Token";
+    final String REFRESH_TOKEN = "Refresh-Token";
 
     @BeforeEach
-    void init() {
-        memberSignupDto = new MemberRequestDto.signup("testEmail@naver.com", "testPassword!123", "testUsername",
-            MBTI.ENTJ);
-        memberLoginDto = new login("testEmail@naver.com", "testPassword!123");
-        memberService.signup(memberSignupDto);
-        memberSignupDto.encodePassword("testPassword@naver.com");
-//        tokenResponseDto = memberService.login(memberLoginDto);
+    void init() throws Exception {
+        tokenDto = new TokenDto();
 
+        // 회원가입
+        memberSignupDto = new MemberSingupTestDto(testEmail, testPassword,
+            testUsername, testMBTI);
+        mockMvc.perform(post("/api/v1/auth/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(gson.toJson(memberSignupDto)));
+
+        // 로그인
+        memberLoginDto = new MemberLoginTestDto(testEmail, testPassword);
+        MockHttpServletResponse response = mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(gson.toJson(memberLoginDto)))
+            .andReturn().getResponse();
+
+        // 토큰 설정
+        tokenDto.setAccessToken(response.getCookie(ACCESS_TOKEN).getValue());
+        tokenDto.setRefreshToken(response.getCookie(REFRESH_TOKEN).getValue());
     }
 
-    @Test
-    @DisplayName("회원 상세정보 조회 테스트 - 컨트롤러")
-    void findMemberDetail() throws Exception {
-        //given
+    @Nested
+    @DisplayName("회원 상세정보 조회 테스트")
+    class testFindMemberDetail {
 
-        //when
-        mockMvc.perform(
-                get("/api/v1/member")
-                    .header("Authorization", tokenResponseDto.getAccessToken())
+        @Test
+        @DisplayName("회원 상세 정보를 조회할 수 있다.")
+        void find_Member_Detail_Success() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(get("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원정보 수정 테스트")
+    class testUpdateMemberDetail {
+
+        @Test
+        @DisplayName("유저네임을 수정할 수 있다.")
+        void update_Member_Username_Success() throws Exception {
+            //given
+            String targetUsername = "targetName";
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(targetUsername, testMBTI,
+                testPassword, testStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("MBTI를 수정할 수 있다.")
+        void update_Member_MBTI_Success() throws Exception {
+            //given
+            String targetMBTI = MBTI.ENFJ.name();
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(testUsername, targetMBTI,
+                testPassword, testStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("비밀번호를 수정할 수 있다.")
+        void update_Member_Password_Success() throws Exception {
+            //given
+            String targetPassword = "targetPassword!123";
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(testUsername, testMBTI,
+                targetPassword, testStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("상태메세지를 수정할 수 있다.")
+        void update_Member_StatusMessage_Success() throws Exception {
+            //given
+            String targetStatusMessage = "targetStatusMessage";
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(testUsername, testMBTI,
+                testPassword, targetStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"thisStringOver12Letters", "w"})
+        @DisplayName("유저네임은" + LimitBound.userNameMinLength + "자 이상" + LimitBound.userNameMaxLength
+            + "자 이하만 입력할 수 있다.")
+        void update_Member_With_Wrong_Username(String wrongUsername) throws Exception {
+            //given
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(wrongUsername, testMBTI,
+                testPassword, testStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isBadRequest()).andDo(print());
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"thisStringOver30LetterForHowBaChuStatusMessageTestCode"})
+        @DisplayName("상태메세지는" + LimitBound.statusMessageMaxLength + "자 이하만 입력할 수 있다.")
+        void update_Member_With_Wrong_StatusMessage_Range(String wrongStatusMessage)
+            throws Exception {
+            //given
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(testUsername, testMBTI,
+                testPassword, wrongStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"thisStringOver24LettersForHowbachu", "wwdsdad"})
+        @DisplayName("비밀번호는" + LimitBound.passwordMinLength + "자 이상" + LimitBound.passwordMaxLength
+            + "자 이하만 입력할 수 있다.")
+        void update_Member_With_Wrong_Password_Range(String wrongPassword) throws Exception {
+            //given
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(testUsername, testMBTI,
+                wrongPassword, testStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {"thisStri321", "wwdsaddsadad", "1111111111"})
+        @DisplayName("비밀번호는 특수문자와 영어, 숫자를 포함해야 한다.")
+        void update_Member_With_Wrong_Password_Type(String wrongPassword)
+            throws Exception {
+            //given
+
+            //when
+            MemberUpdateTestDto memberUpdateDto = new MemberUpdateTestDto(testUsername, testMBTI,
+                wrongPassword, testStatusMessage);
+
+            //then
+            mockMvc.perform(patch("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberUpdateDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원탈퇴 테스트")
+    class testDeleteMember {
+
+        @Test
+        @DisplayName("회원을 탈퇴할 수 있다.")
+        void delete_Member_Success() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(delete("/api/v1/member")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 중복 검사 테스트")
+    class testCheckEmailDuplicate {
+
+        @Test
+        @DisplayName("이메일 중복을 검사할 수 있다.")
+        void check_Email_Duplicate_Success() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(get("/api/v1/member/exists/email/{email}", testEmail)
                     .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.email").exists())
-            .andExpect(jsonPath("$.data.username").exists())
-            .andExpect(jsonPath("$.data.mbti").exists())
-            .andExpect(jsonPath("$.data.statusMessage").exists())
-            .andDo(print());
+                .andExpect(status().isOk());
+        }
 
-        //then
+        @Test
+        @DisplayName("가입되지 않은 이메일도 중복을 검사할 수 있다.")
+        void check_Email_Duplicate_With_Wrong_Email() throws Exception {
+            //given
+            String wrongEmail = "nonRegistered@test.com";
 
-    }
+            //when
 
-    @Test
-    @DisplayName("회원 정보 수정 테스트 - 컨틀롤러")
-    void updateMemberDetail() throws Exception {
-        //given
-        MemberRequestDto.update updateRequestDto = new MemberRequestDto.update("testEmail@naver.com", "testPassword!123",
-            MBTI.ENTJ, "testStatusMessage");
-        Gson gson = new Gson();
-        content = gson.toJson(updateRequestDto);
-
-        //when
-        mockMvc.perform(
-                patch("/api/v1/member")
-                    .header("Authorization", tokenResponseDto.getAccessToken())
-                    .content(content)
+            //then
+            mockMvc.perform(get("/api/v1/member/exists/email/{email}", wrongEmail)
                     .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.email").exists())
-            .andExpect(jsonPath("$.data.username").exists())
-            .andExpect(jsonPath("$.data.mbti").exists())
-            .andExpect(jsonPath("$.data.statusMessage").exists())
-            .andDo(print());
-
-        //then
-        assertThat(memberRepository.findByEmail(memberSignupDto.getEmail()).getUsername()).isEqualTo(
-            updateRequestDto.getUsername());
+                .andExpect(status().isOk());
+        }
     }
 
-    @Test
-    @DisplayName("회원 삭제 테스트 - 컨트롤러")
-    void deleteMember() throws Exception {
-        //given
+    @Nested
+    @DisplayName("닉네임 중복 검사 테스트")
+    class testCheckUsernameDuplicate {
 
-        //when
-        mockMvc.perform(
-                delete("/api/v1/member")
-                    .header("Authorization", tokenResponseDto.getAccessToken())
+        @Test
+        @DisplayName("닉네임 중복을 검사할 수 있다.")
+        void check_Username_Duplicate_Success() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(get("/api/v1/member/exists/username/{username}", testUsername)
                     .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.code").value("204"))
-            .andDo(print());
+                .andExpect(status().isOk());
+        }
 
-        //then
-        assertThrows(CustomException.class, () -> {
-            memberRepository.findByEmail(memberSignupDto.getEmail());
-        });
-    }
+        @Test
+        @DisplayName("가입되지 않은 닉네임도 중복을 검사할 수 있다.")
+        void checkUsernameDuplicateFail() throws Exception {
+            //given
+            String wrongUsername = "nonRegistered";
+            //when
 
-    @Test
-    @DisplayName("이메일로 중복 회원 검사 테스트 - 컨트롤러")
-    void checkEmailDuplicate() throws Exception {
-        //given
-
-        //when
-        mockMvc.perform(
-                get("/api/v1/member/email/{email}/exists", memberSignupDto.getEmail())
+            //then
+            mockMvc.perform(get("/api/v1/member/exists/username/{username}", wrongUsername)
                     .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.status").value("true"))
-            .andDo(print());
-
-        //then
+                .andExpect(status().isOk());
+        }
     }
 
-    @Test
-    @DisplayName("유저네임으로 중복 회원 검사 테스트 - 컨트롤러")
-    void checkUsernameDuplicate() throws Exception {
-        //given
+    @Nested
+    @DisplayName("비밀번호 확인 테스트")
+    class testPasswordVerification {
 
-        //when
-        mockMvc.perform(
-                get("/api/v1/member/username/{username}/exists", memberSignupDto.getUsername())
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.status").value("true"))
-            .andDo(print());
-        //then
+        @Test
+        @DisplayName("비밀번호를 검증할 수 있다.")
+        void check_Password_Verification_Success() throws Exception {
+            //given
+
+            //when
+
+            //then
+            mockMvc.perform(post("/api/v1/member/password-verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(memberLoginDto))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("틀린 비밀번호는 400 에러를 반환한다.")
+        void checkPasswordVerificationFail() throws Exception {
+            //given
+            String wrongPassword = "wrongPassword!123";
+            //when
+
+            //then
+            mockMvc.perform(post("/api/v1/member/password-verification")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(gson.toJson(new MemberLoginTestDto(testEmail, wrongPassword)))
+                    .cookie(new Cookie(ACCESS_TOKEN, tokenDto.getAccessToken()))
+                    .cookie(new Cookie(REFRESH_TOKEN, tokenDto.getRefreshToken())))
+                .andExpect(status().isBadRequest());
+        }
+
     }
+
+    private class MemberSingupTestDto {
+
+        private String email;
+        private String password;
+        private String username;
+        private String mbti;
+
+        public MemberSingupTestDto(String testEmail, String testPassword, String testUsername,
+            String testMBTI) {
+            this.email = testEmail;
+            this.password = testPassword;
+            this.username = testUsername;
+            this.mbti = testMBTI;
+        }
+
+        public void changeEmail(String email) {
+            this.email = email;
+        }
+
+        public void changePassword(String password) {
+            this.password = password;
+        }
+
+        public void changeUsername(String username) {
+            this.username = username;
+        }
+
+        public void changeMBTI(String mbti) {
+            this.mbti = mbti;
+        }
+
+    }
+
+    private class MemberUpdateTestDto {
+
+        private String password;
+        private String username;
+        private String mbti;
+        private String statusMessage;
+
+        public MemberUpdateTestDto(String username, String mbti, String password,
+            String statusMessage) {
+            this.username = username;
+            this.mbti = mbti;
+            this.password = password;
+            this.statusMessage = statusMessage;
+        }
+
+        public void changeUsername(String username) {
+            this.username = username;
+        }
+
+        public void changeMBTI(String mbti) {
+            this.mbti = mbti;
+        }
+
+        public void changePassword(String password) {
+            this.password = password;
+        }
+
+        public void changeStatusMessage(String statusMessage) {
+            this.statusMessage = statusMessage;
+        }
+
+    }
+
+    private class MemberLoginTestDto {
+
+        private String email;
+        private String password;
+
+        public MemberLoginTestDto(String email, String password) {
+            this.email = email;
+            this.password = password;
+        }
+
+        public void changeEmail(String email) {
+            this.email = email;
+        }
+
+        public void changePassword(String password) {
+            this.password = password;
+        }
+    }
+
 }

--- a/src/test/java/com/HowBaChu/howbachu/service/MemberServiceTest.java
+++ b/src/test/java/com/HowBaChu/howbachu/service/MemberServiceTest.java
@@ -13,20 +13,15 @@ import com.HowBaChu.howbachu.domain.entity.Member;
 import com.HowBaChu.howbachu.jwt.JwtProvider;
 import com.HowBaChu.howbachu.repository.MemberRepository;
 import com.HowBaChu.howbachu.repository.RefreshTokenRepository;
-
-import java.util.Optional;
-
+import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.servlet.http.HttpServletResponse;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -58,7 +53,7 @@ class MemberServiceTest {
     @BeforeEach
     void init() {
         memberSignupDto = new signup("testEmail@naver.com", "testPassword!123", "testUsername",
-            MBTI.ENTJ);
+            MBTI.ENTJ.name());
         memberLoginDto = new login("testEmail@naver.com", "testPassword!123");
     }
 
@@ -104,7 +99,7 @@ class MemberServiceTest {
 
         //when
         MemberRequestDto.update updateRequestDto = new update("testEmail@naver.com", "testPassword!123",
-            MBTI.ENTJ, "testStatusMessage");
+            MBTI.ENTJ.name(), "testStatusMessage");
         MemberResponseDto memberResponseDto = memberService.updateMember(memberSignupDto.getEmail(), updateRequestDto);
 
         //then


### PR DESCRIPTION
## ✅ Tasks
멤버 로직에 대한 테스트 코드를 리팩토링하고 필요한 테스트를 추가했습니다.
### Test Code Change
테스트 코드 변경 사항은 다음과 같습니다.
1. @Nested 어노테이션을 이용해 기능별로 여러 테스트 메서드를 묶었습니다. 이를 통해 한 기능에 대한 성공과 실패 테스트를 함께 진행하고 필요한 설정을 해당 클래스 내에서만 사용할 수 있습니다.
2. 쿠키에 대한 로그인 검증을 위해 로그인 mvcMock에서 토큰 dto를 저장하고 해당 토큰을 다음 mockMvc에서 사용합니다.
3. AuthController를 테스트하기 위해 dto에서 validation이 걸리는 것을 방지하고자 AuthControllerTest 클래스에 같은 틀을 공유하는 private dto 클래스를 생성했습니다.
4. 이미지 업로드 테스트 같은 경우는 S3MockTest에서 따로 진행하기 때문에 MemberControllerTest에서 제외했습니다.
### Main Logic Change
main 코드 변경사항은 다음과 같습니다.
1. MBTI가 DTO 내에서 검증되도록 하기 위해 String으로 받은 후 유효성 검사를 마치면 MBTI 클래스로 변경됩니다.
2. Member 회원가입 및 정보 수정 시 잘못된 MBTI 입력에 대한 익셉션을 수정했습니다. 기존에 500에러를 던졌지만 수정 후에는 400 Bad Request가 나가게 됩니다.
3. DTO의 외부에서의 생성자 사용을 막기 위해 private 생성자를 추가했습니다.
4. mail 인증 실패시 403 Forbidden에서 400 Bad Request를 던지는 것으롭 변경했습니다.
5. 테스트 용이성을 위해 유저 권한을 필요로 하지 않는 중복 검사 API들의 엔드포인트를 수정했습니다.